### PR TITLE
feat: improve TUI folding and diff navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-01
+
+### Added
+
+- Generic collapsible sub-blocks in expanded plan resources for large maps, lists, and heredocs.
+- Sub-object navigation in expanded resources: `j`/`k` can move into foldable blocks, and `Enter`/`Space`, `h`, and `l` toggle the selected block.
+- Scoped recursive fold controls: `e` and `c` expand or collapse all foldable content under the selected resource or sub-block.
+- Paired remove/add heredocs render as a single foldable diff section instead of separate old/new heredoc blocks.
+- Adjustable diff context controls: `+`/`=` show more unchanged context around diff hunks, and `-` shows less.
+- One-line viewport scrolling with `Ctrl+E` and `Ctrl+Y` for reviewing large expanded blocks without changing selection.
+
+### Fixed
+
+- Preserve YAML indentation inside heredoc attributes such as `kubectl_manifest.yaml_body_parsed`, including nested Kubernetes lists.
+- Avoid hardcoded provider-specific hiding for noisy `helm_release.metadata` output by using generic collapsible blocks instead.
+
 ## [0.11.0] - 2026-02-25
 
 ### Added
@@ -151,7 +167,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `borderColor`, fix deprecated viewport methods
 - CI: use Go 1.22 and add golangci config
 
-[Unreleased]: https://github.com/CaptShanks/terraprism/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/CaptShanks/terraprism/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/CaptShanks/terraprism/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/CaptShanks/terraprism/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/CaptShanks/terraprism/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/CaptShanks/terraprism/compare/v0.8.0...v0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generic collapsible sub-blocks in expanded plan resources for large maps, lists, and heredocs.
 - Sub-object navigation in expanded resources: `j`/`k` can move into foldable blocks, and `Enter`/`Space`, `h`, and `l` toggle the selected block.
 - Scoped recursive fold controls: `e` and `c` expand or collapse all foldable content under the selected resource or sub-block.
+- Global fold controls: `E` and `C` expand or collapse all visible resources and nested foldable blocks.
 - Paired remove/add heredocs render as a single foldable diff section instead of separate old/new heredoc blocks.
 - Adjustable diff context controls: `+`/`=` show more unchanged context around diff hunks, and `-` shows less.
 - One-line viewport scrolling with `Ctrl+E` and `Ctrl+Y` for reviewing large expanded blocks without changing selection.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ terraform plan -no-color | terraprism -p
 | `h` / `←` / `⌫` | Collapse current resource or foldable sub-block |
 | `e` | Expand all resources, or all foldable sub-blocks in the current scope |
 | `c` | Collapse all resources, or all foldable sub-blocks in the current scope |
+| `E` | Expand all visible resources and all nested foldable sub-blocks |
+| `C` | Collapse all visible resources and all nested foldable sub-blocks |
 
 Large maps, lists, and heredocs inside expanded resources become foldable sub-blocks. Large sub-blocks collapse by default; use `l`/`→` or `Enter`/`Space` to expand them, then `Ctrl+E`/`Ctrl+Y` to scroll through the expanded content without moving the selection. When a resource or sub-block is selected, `e` and `c` recursively expand or collapse the foldable content underneath that selection.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  Collapsible resources • Filter & sort • Syntax-highlighted HCL • Vim-style navigation • Auto light/dark mode
+  Collapsible resources and sub-blocks • Filter & sort • Syntax-highlighted HCL • Vim-style navigation • Auto light/dark mode
 </p>
 
 ---
@@ -27,11 +27,11 @@
 ## Features
 
 - **Syntax-highlighted HCL** - Full color-coded display of your plan
-- **Collapsible resources** - Expand/collapse individual resources or all at once
+- **Collapsible resources and sub-blocks** - Expand/collapse resources, large maps, lists, and heredocs
 - **Status filter** - Filter resources by action (create, destroy, update, replace, read, etc.)
 - **Sort** - Sort by plan order, action, address, or resource type
 - **Search** - Find resources by name, type, or address (works with filters)
-- **Vim-style navigation** - j/k/gg/G/d/u and more
+- **Vim-style navigation** - j/k/gg/G/d/u plus line scrolling for large blocks
 - **Auto light/dark mode** - Detects your terminal background
 - **Format support** - Works with Terraform 0.11+ and OpenTofu
 - **Full-line selection** - Clear visual indicator of selected resource
@@ -132,21 +132,29 @@ terraform plan -no-color | terraprism -p
 ### Navigation
 | Key | Action |
 |-----|--------|
-| `j` / `↓` | Move to next resource |
-| `k` / `↑` | Move to previous resource |
+| `j` / `↓` | Move to next resource or foldable sub-block |
+| `k` / `↑` | Move to previous resource or foldable sub-block |
 | `gg` | Jump to first resource |
 | `G` | Jump to last resource |
 | `d` / `Ctrl+D` | Scroll half page down |
 | `u` / `Ctrl+U` | Scroll half page up |
+| `Ctrl+E` | Scroll one line down |
+| `Ctrl+Y` | Scroll one line up |
+| `+` / `=` | Show more unchanged context around diff hunks |
+| `-` | Show less unchanged context around diff hunks |
 
 ### Expand/Collapse
 | Key | Action |
 |-----|--------|
-| `Enter` / `Space` | Toggle current resource |
-| `l` / `→` | Expand current resource |
-| `h` / `←` / `⌫` | Collapse current resource |
-| `e` | Expand all resources |
-| `c` | Collapse all resources |
+| `Enter` / `Space` | Toggle current resource or foldable sub-block |
+| `l` / `→` | Expand current resource or foldable sub-block |
+| `h` / `←` / `⌫` | Collapse current resource or foldable sub-block |
+| `e` | Expand all resources, or all foldable sub-blocks in the current scope |
+| `c` | Collapse all resources, or all foldable sub-blocks in the current scope |
+
+Large maps, lists, and heredocs inside expanded resources become foldable sub-blocks. Large sub-blocks collapse by default; use `l`/`→` or `Enter`/`Space` to expand them, then `Ctrl+E`/`Ctrl+Y` to scroll through the expanded content without moving the selection. When a resource or sub-block is selected, `e` and `c` recursively expand or collapse the foldable content underneath that selection.
+
+Paired remove/add heredocs are shown as one foldable diff section so large values changes can be reviewed as a focused line diff. Use `+`/`=` and `-` to increase or decrease the unchanged context shown around each diff hunk.
 
 ### Search
 | Key | Action |
@@ -353,12 +361,12 @@ Large Terraform plans can be difficult to review:
 
 Terra-Prism solves these problems:
 
-- Collapsible sections for high-level overview
+- Collapsible sections and sub-blocks for high-level overview
 - Filter by status to focus on creates, destroys, updates, etc.
 - Sort by action, address, or type for organized review
 - Consistent syntax highlighting
 - Search to find specific resources (works with filters)
-- Vim-style navigation for efficiency
+- Vim-style navigation for resources, sub-blocks, and large expanded content
 - Auto-scrolling keeps selection visible
 
 ## Inspired By

--- a/cmd/terraprism/main.go
+++ b/cmd/terraprism/main.go
@@ -17,7 +17,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-const version = "0.11.0"
+const version = "0.12.0"
 
 var (
 	printMode  = false

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -143,13 +143,19 @@ func parseNewFormat(plan *Plan, lines []string) {
 	for i := 0; i < len(lines); i++ {
 		line := lines[i]
 		if match := resourceRegex.FindStringSubmatch(line); match != nil {
+			address := strings.TrimSpace(match[1])
+			if !isTerraformResourceAddress(address) {
+				if inResourceBlock && currentResource != nil {
+					currentResource.RawLines = append(currentResource.RawLines, line)
+				}
+				continue
+			}
 			if currentResource != nil {
 				plan.Resources = append(plan.Resources, *currentResource)
 			}
-			address := strings.TrimSpace(match[1])
 			currentResource = &Resource{
 				Address:  address,
-				Action:  parseActionFromLine(line),
+				Action:   parseActionFromLine(line),
 				RawLines: []string{line},
 			}
 			if parts := strings.Split(address, "."); len(parts) >= 2 {
@@ -183,10 +189,33 @@ func parseNewFormat(plan *Plan, lines []string) {
 	}
 }
 
+var terraformAddressIdentRegex = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*$`)
+
+func isTerraformResourceAddress(address string) bool {
+	address = strings.TrimSpace(address)
+	if address == "" || strings.HasPrefix(address, "-") {
+		return false
+	}
+	parts := strings.Split(address, ".")
+	if len(parts) < 2 {
+		return false
+	}
+	for _, part := range parts[len(parts)-2:] {
+		base := strings.TrimSpace(part)
+		if idx := strings.Index(base, "["); idx >= 0 {
+			base = base[:idx]
+		}
+		if !terraformAddressIdentRegex.MatchString(base) {
+			return false
+		}
+	}
+	return true
+}
+
 type oldFormatResourcePattern struct {
-	re       *regexp.Regexp
-	action   Action
-	noColon  bool // resource lines (not attribute lines) must not contain ":"
+	re      *regexp.Regexp
+	action  Action
+	noColon bool // resource lines (not attribute lines) must not contain ":"
 }
 
 var oldFormatPatterns = []oldFormatResourcePattern{
@@ -203,7 +232,11 @@ func parseOldFormatResourceLine(line string) (address string, action Action, ok 
 			continue
 		}
 		if match := p.re.FindStringSubmatch(line); match != nil {
-			return strings.TrimSpace(match[1]), p.action, true
+			address := strings.TrimSpace(match[1])
+			if !isTerraformResourceAddress(address) {
+				continue
+			}
+			return address, p.action, true
 		}
 	}
 	return "", "", false

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -108,6 +109,39 @@ Plan: 1 to add, 1 to change, 1 to destroy.
 	}
 }
 
+func TestParseOldFormatIgnoresHelmValuesCommentsThatLookLikeResources(t *testing.T) {
+	input := `
+~ module.tempo.helm_release.chart[0]
+    values: <<-EOT
+      rollout_operator:
+~ -- Enable rollout-operator. It will be updated
+        enabled: true
+      distributor:
+        enabled: true
+    EOT
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+`
+
+	plan, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Failed to parse plan: %v", err)
+	}
+
+	if len(plan.Resources) != 1 {
+		t.Fatalf("Expected 1 resource, got %d: %#v", len(plan.Resources), plan.Resources)
+	}
+	if plan.Resources[0].Address != "module.tempo.helm_release.chart[0]" {
+		t.Fatalf("Expected helm_release resource address, got %q", plan.Resources[0].Address)
+	}
+	for _, rawLine := range plan.Resources[0].RawLines {
+		if strings.Contains(rawLine, "Enable rollout-operator") {
+			return
+		}
+	}
+	t.Fatal("Expected Helm values comment-like line to remain in the resource raw lines")
+}
+
 func TestParseReplace(t *testing.T) {
 	input := `
   # aws_instance.replaced must be replaced
@@ -131,6 +165,52 @@ Plan: 1 to add, 0 to change, 1 to destroy.
 	if plan.Resources[0].Action != ActionReplace {
 		t.Errorf("Expected action to be replace, got %s", plan.Resources[0].Action)
 	}
+}
+
+func TestParseNewFormatIgnoresHelmValuesCommentsThatLookLikeHeaders(t *testing.T) {
+	input := `
+Terraform will perform the following actions:
+
+  # module.tempo.helm_release.chart[0] will be updated in-place
+  ~ resource "helm_release" "chart" {
+      ~ values = [
+          - <<-EOT
+              rollout_operator:
+                # -- Enable rollout-operator. It must be enabled when using Zone Aware Replication.
+                enabled: true
+                image:
+                  repository: example.com/docker.io/grafana/rollout-operator
+            EOT,
+          + <<-EOT
+              rollout_operator:
+                # -- Enable rollout-operator. It must be enabled when using Zone Aware Replication.
+                enabled: true
+                image:
+                  repository: example.com/docker.io/grafana/rollout-operator
+            EOT,
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+`
+
+	plan, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Failed to parse plan: %v", err)
+	}
+
+	if len(plan.Resources) != 1 {
+		t.Fatalf("Expected 1 resource, got %d: %#v", len(plan.Resources), plan.Resources)
+	}
+	if plan.Resources[0].Address != "module.tempo.helm_release.chart[0]" {
+		t.Fatalf("Expected helm_release resource address, got %q", plan.Resources[0].Address)
+	}
+	for _, rawLine := range plan.Resources[0].RawLines {
+		if strings.Contains(rawLine, "Enable rollout-operator") {
+			return
+		}
+	}
+	t.Fatal("Expected Helm values comment to remain in the resource raw lines")
 }
 
 func TestParseOutputChanges(t *testing.T) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -364,7 +364,9 @@ var normalKeyHandlers = map[string]normalKeyHandler{
 	"enter":     handleKeyEnter,
 	" ":         handleKeyEnter,
 	"e":         handleKeyExpandAll,
+	"E":         handleKeyExpandEverything,
 	"c":         handleKeyCollapseAll,
+	"C":         handleKeyCollapseEverything,
 	"f":         handleKeyFilter,
 	"s":         handleKeySort,
 	"/":         handleKeySearch,
@@ -498,6 +500,16 @@ func handleKeyCollapseAll(m Model) (Model, tea.Cmd, bool) {
 	}
 
 	m.collapseAll()
+	return m, nil, true
+}
+
+func handleKeyExpandEverything(m Model) (Model, tea.Cmd, bool) {
+	m.expandEverything()
+	return m, nil, true
+}
+
+func handleKeyCollapseEverything(m Model) (Model, tea.Cmd, bool) {
+	m.collapseEverything()
 	return m, nil, true
 }
 
@@ -862,6 +874,21 @@ func (m *Model) setCurrentScopeFoldsCollapsed(collapsed bool) bool {
 	return true
 }
 
+func (m *Model) setDisplayedFoldsCollapsed(collapsed bool) {
+	for _, resourceIdx := range m.displayedResourceIndices() {
+		if resourceIdx < 0 || resourceIdx >= len(m.plan.Resources) {
+			continue
+		}
+		r := m.plan.Resources[resourceIdx]
+		if len(r.RawLines) <= 1 {
+			continue
+		}
+		for _, block := range findFoldBlocks(r, r.RawLines[1:]) {
+			m.foldedBlocks[block.Key] = collapsed
+		}
+	}
+}
+
 // expandAll expands all visible (filtered/sorted) resources
 func (m *Model) expandAll() {
 	for _, idx := range m.displayedResourceIndices() {
@@ -876,6 +903,28 @@ func (m *Model) collapseAll() {
 	for _, idx := range m.displayedResourceIndices() {
 		m.expanded[idx] = false
 	}
+	m.blockCursor = -1
+	m.updateViewportContent()
+	m.ensureCursorVisible()
+}
+
+// expandEverything expands all visible resources and their nested fold blocks.
+func (m *Model) expandEverything() {
+	for _, idx := range m.displayedResourceIndices() {
+		m.expanded[idx] = true
+	}
+	m.setDisplayedFoldsCollapsed(false)
+	m.blockCursor = -1
+	m.updateViewportContent()
+	m.ensureCursorVisible()
+}
+
+// collapseEverything collapses all visible resources and their nested fold blocks.
+func (m *Model) collapseEverything() {
+	for _, idx := range m.displayedResourceIndices() {
+		m.expanded[idx] = false
+	}
+	m.setDisplayedFoldsCollapsed(true)
 	m.blockCursor = -1
 	m.updateViewportContent()
 	m.ensureCursorVisible()
@@ -2465,9 +2514,9 @@ func (m Model) viewHelpFooter() string {
 	}
 
 	helpOptions := []string{
-		"j/k/↑↓: navigate • l/→: expand • h/←/⌫: collapse • e/c: expand/collapse scope • +/-: diff context • Ctrl+E/Y: line scroll • d/u: page scroll • gg/G: top/bottom • /: search • f: filter • s: sort • q: quit",
-		"j/k: nav • l/h: fold • e/c: scope • +/-: diff ctx • Ctrl+E/Y: line • d/u: page • /: search • f/s • q",
-		"j/k nav • l/h fold • e/c scope • +/- diff • Ctrl+E/Y scroll • / search • q",
+		"j/k/↑↓: navigate • l/→: expand • h/←/⌫: collapse • e/c: scope • E/C: all • +/-: diff context • Ctrl+E/Y: line scroll • d/u: page scroll • gg/G: top/bottom • /: search • f: filter • s: sort • q: quit",
+		"j/k: nav • l/h: fold • e/c: scope • E/C: all • +/-: diff ctx • Ctrl+E/Y: line • d/u: page • /: search • f/s • q",
+		"j/k nav • l/h fold • e/c scope • E/C all • +/- diff • Ctrl+E/Y scroll • / search • q",
 		"j/k nav • l/h fold • e/c • q",
 	}
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -18,20 +18,24 @@ import (
 
 // Model represents the TUI state
 type Model struct {
-	plan          *parser.Plan
-	cursor        int
-	expanded      map[int]bool
-	viewport      viewport.Model
-	ready         bool
-	width         int
-	height        int
-	searching     bool
-	searchInput   textinput.Model
-	searchQuery   string
-	searchMatches []int
-	currentMatch  int
+	plan               *parser.Plan
+	cursor             int
+	expanded           map[int]bool
+	foldedBlocks       map[string]bool
+	blockCursor        int
+	diffContext        int
+	viewport           viewport.Model
+	ready              bool
+	width              int
+	height             int
+	searching          bool
+	searchInput        textinput.Model
+	searchQuery        string
+	searchMatches      []int
+	currentMatch       int
 	pendingG           bool  // Track if 'g' was pressed, waiting for second 'g'
 	resourceLineStarts []int // rendered line offset per resource (populated during render)
+	selectedLineStart  int   // rendered line offset for the current resource or sub-block cursor
 	contentLineCount   int   // total rendered content lines (excluding padding)
 
 	// Apply mode fields
@@ -43,13 +47,13 @@ type Model struct {
 
 	// Status filter fields
 	statusFilters map[parser.Action]bool // true = show resources with this action
-	filtering     bool                    // filter picker is open
-	filterCursor  int                     // cursor in filter picker
+	filtering     bool                   // filter picker is open
+	filterCursor  int                    // cursor in filter picker
 
 	// Sort fields
-	sortOrder   SortOrder // default, byAction, byAddress, byType
-	sorting     bool      // sort picker is open
-	sortCursor  int       // cursor in sort picker
+	sortOrder  SortOrder // default, byAction, byAddress, byType
+	sorting    bool      // sort picker is open
+	sortCursor int       // cursor in sort picker
 
 	// Update nudge
 	currentVersion  string // for update check
@@ -185,6 +189,9 @@ func NewModel(plan *parser.Plan, version string) Model {
 	return Model{
 		plan:           plan,
 		expanded:       make(map[int]bool),
+		foldedBlocks:   make(map[string]bool),
+		blockCursor:    -1,
+		diffContext:    defaultDiffContext,
 		searchInput:    ti,
 		searchMatches:  []int{},
 		applyMode:      false,
@@ -204,6 +211,9 @@ func NewModelWithApply(plan *parser.Plan, planFile, tfCommand, version string) M
 	return Model{
 		plan:           plan,
 		expanded:       make(map[int]bool),
+		foldedBlocks:   make(map[string]bool),
+		blockCursor:    -1,
+		diffContext:    defaultDiffContext,
 		searchInput:    ti,
 		searchMatches:  []int{},
 		applyMode:      true,
@@ -321,46 +331,81 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(cmds...)
 }
 
+const (
+	defaultDiffContext = 3
+	diffContextStep    = 3
+	maxDiffContext     = 30
+)
+
+func (m Model) diffContextSize() int {
+	return clampDiffContext(m.diffContext)
+}
+
+func clampDiffContext(context int) int {
+	if context < 0 {
+		return 0
+	}
+	if context > maxDiffContext {
+		return maxDiffContext
+	}
+	return context
+}
+
 // normalKeyHandler handles a single key in normal mode. Returns (model, cmd, quit).
 type normalKeyHandler func(m Model) (Model, tea.Cmd, bool)
 
 var normalKeyHandlers = map[string]normalKeyHandler{
-	"q": func(m Model) (Model, tea.Cmd, bool) { return m, tea.Quit, true },
-	"ctrl+c": func(m Model) (Model, tea.Cmd, bool) { return m, tea.Quit, true },
-	"up":    handleKeyUp,
-	"k":     handleKeyUp,
-	"down":  handleKeyDown,
-	"j":     handleKeyDown,
-	"enter": handleKeyEnter,
-	" ":     handleKeyEnter,
-	"e":     handleKeyExpandAll,
-	"c":     handleKeyCollapseAll,
-	"f":     handleKeyFilter,
-	"s":     handleKeySort,
-	"/":     handleKeySearch,
-	"n":     handleKeyNextMatch,
-	"N":     handleKeyPrevMatch,
-	"esc":   handleKeyEsc,
+	"q":         func(m Model) (Model, tea.Cmd, bool) { return m, tea.Quit, true },
+	"ctrl+c":    func(m Model) (Model, tea.Cmd, bool) { return m, tea.Quit, true },
+	"up":        handleKeyUp,
+	"k":         handleKeyUp,
+	"down":      handleKeyDown,
+	"j":         handleKeyDown,
+	"enter":     handleKeyEnter,
+	" ":         handleKeyEnter,
+	"e":         handleKeyExpandAll,
+	"c":         handleKeyCollapseAll,
+	"f":         handleKeyFilter,
+	"s":         handleKeySort,
+	"/":         handleKeySearch,
+	"n":         handleKeyNextMatch,
+	"N":         handleKeyPrevMatch,
+	"esc":       handleKeyEsc,
 	"backspace": handleKeyCollapseCurrent,
-	"h":     handleKeyCollapseCurrent,
-	"left":  handleKeyCollapseCurrent,
-	"d":     handleKeyHalfPageDown,
-	"ctrl+d": handleKeyHalfPageDown,
-	"u":     handleKeyHalfPageUp,
-	"ctrl+u": handleKeyHalfPageUp,
-	"g":     handleKeyG,
-	"G":     handleKeyGG,
-	"pgup":  handleKeyPgUp,
-	"pgdown": handleKeyPgDown,
-	"l":     handleKeyExpandCurrent,
-	"right": handleKeyExpandCurrent,
-	"a":     handleKeyApply,
-	"y":     handleKeyConfirmApply,
+	"h":         handleKeyCollapseCurrent,
+	"left":      handleKeyCollapseCurrent,
+	"d":         handleKeyHalfPageDown,
+	"ctrl+d":    handleKeyHalfPageDown,
+	"u":         handleKeyHalfPageUp,
+	"ctrl+u":    handleKeyHalfPageUp,
+	"ctrl+e":    handleKeyScrollLineDown,
+	"ctrl+y":    handleKeyScrollLineUp,
+	"+":         handleKeyIncreaseDiffContext,
+	"=":         handleKeyIncreaseDiffContext,
+	"-":         handleKeyDecreaseDiffContext,
+	"g":         handleKeyG,
+	"G":         handleKeyGG,
+	"pgup":      handleKeyPgUp,
+	"pgdown":    handleKeyPgDown,
+	"l":         handleKeyExpandCurrent,
+	"right":     handleKeyExpandCurrent,
+	"a":         handleKeyApply,
+	"y":         handleKeyConfirmApply,
 }
 
 func handleKeyUp(m Model) (Model, tea.Cmd, bool) {
+	if m.blockCursor >= 0 {
+		m.blockCursor--
+		m.updateViewportContent()
+		m.ensureCursorVisible()
+		return m, nil, true
+	}
+
 	if m.cursor > 0 {
 		m.cursor--
+		if blocks := m.currentFoldBlocks(); m.expanded[m.currentResourceIndex()] && len(blocks) > 0 {
+			m.blockCursor = len(blocks) - 1
+		}
 		m.updateViewportContent()
 		m.ensureCursorVisible()
 	} else {
@@ -373,6 +418,7 @@ func handleKeyUp(m Model) (Model, tea.Cmd, bool) {
 func (m Model) handleSearchArrowUp() Model {
 	if m.cursor > 0 {
 		m.cursor--
+		m.blockCursor = -1
 		m.updateViewportContent()
 		m.ensureCursorVisible()
 	} else {
@@ -386,6 +432,7 @@ func (m Model) handleSearchArrowDown() Model {
 	displayed := m.displayedResourceIndices()
 	if m.cursor < len(displayed)-1 {
 		m.cursor++
+		m.blockCursor = -1
 		m.updateViewportContent()
 		m.ensureCursorVisible()
 	} else {
@@ -395,9 +442,17 @@ func (m Model) handleSearchArrowDown() Model {
 }
 
 func handleKeyDown(m Model) (Model, tea.Cmd, bool) {
+	if blocks := m.currentFoldBlocks(); m.expanded[m.currentResourceIndex()] && m.blockCursor < len(blocks)-1 {
+		m.blockCursor++
+		m.updateViewportContent()
+		m.ensureCursorVisible()
+		return m, nil, true
+	}
+
 	filtered := m.displayedResourceIndices()
 	if m.cursor < len(filtered)-1 {
 		m.cursor++
+		m.blockCursor = -1
 		m.updateViewportContent()
 		m.ensureCursorVisible()
 	} else {
@@ -407,10 +462,17 @@ func handleKeyDown(m Model) (Model, tea.Cmd, bool) {
 }
 
 func handleKeyEnter(m Model) (Model, tea.Cmd, bool) {
+	if m.toggleCurrentFold() {
+		m.updateViewportContent()
+		m.ensureCursorVisible()
+		return m, nil, true
+	}
+
 	filtered := m.displayedResourceIndices()
 	if len(filtered) > 0 && m.cursor >= 0 && m.cursor < len(filtered) {
 		resourceIdx := filtered[m.cursor]
 		m.expanded[resourceIdx] = !m.expanded[resourceIdx]
+		m.blockCursor = -1
 	}
 	m.updateViewportContent()
 	m.scrollForExpanded()
@@ -418,11 +480,23 @@ func handleKeyEnter(m Model) (Model, tea.Cmd, bool) {
 }
 
 func handleKeyExpandAll(m Model) (Model, tea.Cmd, bool) {
+	if m.setCurrentScopeFoldsCollapsed(false) {
+		m.updateViewportContent()
+		m.ensureCursorVisible()
+		return m, nil, true
+	}
+
 	m.expandAll()
 	return m, nil, true
 }
 
 func handleKeyCollapseAll(m Model) (Model, tea.Cmd, bool) {
+	if m.setCurrentScopeFoldsCollapsed(true) {
+		m.updateViewportContent()
+		m.ensureCursorVisible()
+		return m, nil, true
+	}
+
 	m.collapseAll()
 	return m, nil, true
 }
@@ -476,9 +550,16 @@ func handleKeyEsc(m Model) (Model, tea.Cmd, bool) {
 }
 
 func handleKeyCollapseCurrent(m Model) (Model, tea.Cmd, bool) {
+	if m.setCurrentFoldCollapsed(true) {
+		m.updateViewportContent()
+		m.ensureCursorVisible()
+		return m, nil, true
+	}
+
 	filtered := m.displayedResourceIndices()
 	if len(filtered) > 0 && m.cursor >= 0 && m.cursor < len(filtered) {
 		m.expanded[filtered[m.cursor]] = false
+		m.blockCursor = -1
 	}
 	m.updateViewportContent()
 	m.ensureCursorVisible()
@@ -492,6 +573,34 @@ func handleKeyHalfPageDown(m Model) (Model, tea.Cmd, bool) {
 
 func handleKeyHalfPageUp(m Model) (Model, tea.Cmd, bool) {
 	m.scrollHalfPageUp()
+	return m, nil, true
+}
+
+func handleKeyScrollLineDown(m Model) (Model, tea.Cmd, bool) {
+	m.viewport.SetYOffset(m.viewport.YOffset + 1)
+	return m, nil, true
+}
+
+func handleKeyScrollLineUp(m Model) (Model, tea.Cmd, bool) {
+	newOffset := m.viewport.YOffset - 1
+	if newOffset < 0 {
+		newOffset = 0
+	}
+	m.viewport.SetYOffset(newOffset)
+	return m, nil, true
+}
+
+func handleKeyIncreaseDiffContext(m Model) (Model, tea.Cmd, bool) {
+	m.diffContext = clampDiffContext(m.diffContextSize() + diffContextStep)
+	m.updateViewportContent()
+	m.ensureCursorVisible()
+	return m, nil, true
+}
+
+func handleKeyDecreaseDiffContext(m Model) (Model, tea.Cmd, bool) {
+	m.diffContext = clampDiffContext(m.diffContextSize() - diffContextStep)
+	m.updateViewportContent()
+	m.ensureCursorVisible()
 	return m, nil, true
 }
 
@@ -517,6 +626,12 @@ func handleKeyPgDown(m Model) (Model, tea.Cmd, bool) {
 }
 
 func handleKeyExpandCurrent(m Model) (Model, tea.Cmd, bool) {
+	if m.setCurrentFoldCollapsed(false) {
+		m.updateViewportContent()
+		m.ensureCursorVisible()
+		return m, nil, true
+	}
+
 	filtered := m.displayedResourceIndices()
 	if len(filtered) > 0 && m.cursor >= 0 && m.cursor < len(filtered) {
 		m.expanded[filtered[m.cursor]] = true
@@ -667,9 +782,84 @@ func (m *Model) clampCursorAndRefreshSearch() {
 			m.cursor = 0
 		}
 	}
+	m.blockCursor = -1
 	if m.searchQuery != "" {
 		m.performSearch()
 	}
+}
+
+func (m Model) currentResourceIndex() int {
+	displayed := m.displayedResourceIndices()
+	if len(displayed) == 0 || m.cursor < 0 || m.cursor >= len(displayed) {
+		return -1
+	}
+	return displayed[m.cursor]
+}
+
+func (m Model) currentFoldBlocks() []foldBlock {
+	resourceIdx := m.currentResourceIndex()
+	if resourceIdx < 0 || resourceIdx >= len(m.plan.Resources) {
+		return nil
+	}
+	r := m.plan.Resources[resourceIdx]
+	if len(r.RawLines) <= 1 {
+		return nil
+	}
+	return m.visibleFoldBlocks(findFoldBlocks(r, r.RawLines[1:]))
+}
+
+func (m *Model) currentFoldBlock() (foldBlock, bool) {
+	blocks := m.currentFoldBlocks()
+	if m.blockCursor < 0 || m.blockCursor >= len(blocks) {
+		return foldBlock{}, false
+	}
+	return blocks[m.blockCursor], true
+}
+
+func (m *Model) toggleCurrentFold() bool {
+	block, ok := m.currentFoldBlock()
+	if !ok {
+		return false
+	}
+	m.foldedBlocks[block.Key] = !m.isFoldCollapsed(block)
+	return true
+}
+
+func (m *Model) setCurrentFoldCollapsed(collapsed bool) bool {
+	block, ok := m.currentFoldBlock()
+	if !ok {
+		return false
+	}
+	m.foldedBlocks[block.Key] = collapsed
+	return true
+}
+
+func (m *Model) setCurrentScopeFoldsCollapsed(collapsed bool) bool {
+	resourceIdx := m.currentResourceIndex()
+	if resourceIdx < 0 || resourceIdx >= len(m.plan.Resources) || !m.expanded[resourceIdx] {
+		return false
+	}
+
+	blocks := findFoldBlocks(m.plan.Resources[resourceIdx], m.plan.Resources[resourceIdx].RawLines[1:])
+	if len(blocks) == 0 {
+		return false
+	}
+
+	if current, ok := m.currentFoldBlock(); ok {
+		changed := false
+		for _, block := range blocks {
+			if block.Start >= current.Start && block.End <= current.End {
+				m.foldedBlocks[block.Key] = collapsed
+				changed = true
+			}
+		}
+		return changed
+	}
+
+	for _, block := range blocks {
+		m.foldedBlocks[block.Key] = collapsed
+	}
+	return true
 }
 
 // expandAll expands all visible (filtered/sorted) resources
@@ -686,6 +876,7 @@ func (m *Model) collapseAll() {
 	for _, idx := range m.displayedResourceIndices() {
 		m.expanded[idx] = false
 	}
+	m.blockCursor = -1
 	m.updateViewportContent()
 	m.ensureCursorVisible()
 }
@@ -818,6 +1009,7 @@ func (m *Model) performSearch() {
 	if len(m.searchMatches) > 0 {
 		m.cursor = 0 // first item in filtered display
 		m.currentMatch = 0
+		m.blockCursor = -1
 	}
 }
 
@@ -838,7 +1030,10 @@ func (m *Model) ensureCursorVisible() {
 		return
 	}
 
-	lineNum := m.resourceLineStarts[m.cursor]
+	lineNum := m.selectedLineStart
+	if lineNum < 0 {
+		lineNum = m.resourceLineStarts[m.cursor]
+	}
 
 	topLine := m.viewport.YOffset
 	bottomLine := topLine + m.viewport.Height - 1
@@ -903,6 +1098,7 @@ func (m *Model) renderResources() string {
 		return b.String()
 	}
 
+	m.selectedLineStart = 0
 	for displayIdx, resourceIdx := range displayed {
 		m.resourceLineStarts[displayIdx] = lineCount
 		r := m.plan.Resources[resourceIdx]
@@ -910,6 +1106,9 @@ func (m *Model) renderResources() string {
 		isSelected := displayIdx == m.cursor
 		isExpanded := m.expanded[resourceIdx]
 		isMatch := m.searchQuery != "" // when filtering, all displayed items match
+		if isSelected && m.blockCursor < 0 {
+			m.selectedLineStart = lineCount
+		}
 
 		if isSelected {
 			line := m.renderSelectedResourceLine(r, isExpanded, isMatch)
@@ -922,10 +1121,9 @@ func (m *Model) renderResources() string {
 		lineCount++
 
 		if isExpanded && len(r.RawLines) > 1 {
-			before := b.Len()
-			m.renderExpandedContent(&b, r.RawLines[1:], r.Action)
+			m.renderExpandedContent(&b, r, isSelected && m.blockCursor >= 0, &lineCount)
 			b.WriteString("\n")
-			lineCount += strings.Count(b.String()[before:], "\n")
+			lineCount++
 		}
 	}
 
@@ -945,30 +1143,452 @@ func (m *Model) renderResources() string {
 	return b.String()
 }
 
-// renderExpandedContent renders the expanded lines for a resource, applying
-// word wrapping, userdata decoding, and YAML/heredoc diff detection.
-func (m Model) renderExpandedContent(b *strings.Builder, lines []string, action parser.Action) {
-	maxWidth := m.viewport.Width
+const defaultCollapsedFoldLines = 30
 
+type foldBlock struct {
+	Start          int
+	End            int
+	Key            string
+	LineCount      int
+	Heredoc        bool
+	HeredocPair    bool
+	OldEnd         int
+	AddStart       int
+	OldLineCount   int
+	NewLineCount   int
+	HeredocEndMark string
+}
+
+func findFoldBlocks(r parser.Resource, lines []string) []foldBlock {
+	var blocks []foldBlock
 	for idx := 0; idx < len(lines); idx++ {
-		line := lines[idx]
-
-		if decoded, ok := m.tryRenderUserdata(line, action, maxWidth); ok {
-			b.WriteString(decoded)
-			b.WriteString("\n")
+		if idx == 0 && isResourceDeclarationLine(lines[idx]) {
 			continue
 		}
 
-		if consumed, rendered := m.tryRenderHeredocDiff(lines, idx, action, maxWidth); consumed > 0 {
+		if block, ok := findHeredocPairFold(r, lines, idx); ok {
+			blocks = append(blocks, block)
+			idx = block.End - 1
+			continue
+		}
+
+		if marker := parseHeredocMarkerFromLine(lines[idx]); marker != "" {
+			end := findHeredocBlockEnd(lines, idx+1, marker)
+			if end > idx+1 {
+				blocks = append(blocks, newFoldBlock(r, lines, idx, end, true))
+				idx = end - 1
+			}
+			continue
+		}
+
+		if !isFoldableStructureStart(lines[idx]) {
+			continue
+		}
+		end := findBalancedStructureBlockEnd(lines, idx)
+		if end > idx+1 {
+			blocks = append(blocks, newFoldBlock(r, lines, idx, end, false))
+		}
+	}
+	return blocks
+}
+
+func findHeredocPairFold(r parser.Resource, lines []string, idx int) (foldBlock, bool) {
+	if idx >= len(lines) {
+		return foldBlock{}, false
+	}
+
+	trimmed := strings.TrimLeft(lines[idx], " \t")
+	if !strings.HasPrefix(trimmed, "- ") || !isHeredocMarker(trimmed[2:]) {
+		return foldBlock{}, false
+	}
+
+	endMarker := parseHeredocEnd(trimmed[2:])
+	if endMarker == "" {
+		return foldBlock{}, false
+	}
+
+	oldEnd := findHeredocBlockEnd(lines, idx+1, endMarker)
+	if oldEnd < 0 {
+		return foldBlock{}, false
+	}
+
+	addStart := findAddHeredocStart(lines, oldEnd)
+	if addStart < 0 {
+		return foldBlock{}, false
+	}
+
+	newEnd := findHeredocBlockEnd(lines, addStart+1, endMarker)
+	if newEnd < 0 {
+		return foldBlock{}, false
+	}
+
+	block := newFoldBlock(r, lines, idx, newEnd, false)
+	block.HeredocPair = true
+	block.OldEnd = oldEnd
+	block.AddStart = addStart
+	block.OldLineCount = oldEnd - idx - 2
+	block.NewLineCount = newEnd - addStart - 2
+	block.HeredocEndMark = endMarker
+	if block.OldLineCount < 0 {
+		block.OldLineCount = 0
+	}
+	if block.NewLineCount < 0 {
+		block.NewLineCount = 0
+	}
+	block.Key = fmt.Sprintf("%s:%d:heredoc-diff:%s", r.Address, idx, endMarker)
+	return block, true
+}
+
+func (m *Model) visibleFoldBlocks(blocks []foldBlock) []foldBlock {
+	visible := make([]foldBlock, 0, len(blocks))
+	var ancestors []foldBlock
+
+	for _, block := range blocks {
+		for len(ancestors) > 0 && block.Start >= ancestors[len(ancestors)-1].End {
+			ancestors = ancestors[:len(ancestors)-1]
+		}
+
+		hidden := false
+		for _, ancestor := range ancestors {
+			if m.isFoldCollapsed(ancestor) {
+				hidden = true
+				break
+			}
+		}
+		if !hidden {
+			visible = append(visible, block)
+		}
+
+		ancestors = append(ancestors, block)
+	}
+
+	return visible
+}
+
+func newFoldBlock(r parser.Resource, lines []string, start, end int, heredoc bool) foldBlock {
+	key := fmt.Sprintf("%s:%d:%s", r.Address, start, strings.TrimSpace(lines[start]))
+	lineCount := end - start - 1
+	if lineCount < 0 {
+		lineCount = 0
+	}
+	return foldBlock{Start: start, End: end, Key: key, LineCount: lineCount, Heredoc: heredoc}
+}
+
+func isResourceDeclarationLine(line string) bool {
+	content := strings.TrimSpace(stripDiffPrefix(strings.TrimLeft(line, " \t")))
+	return strings.HasPrefix(content, "resource ") || strings.HasPrefix(content, "data ")
+}
+
+func isFoldableStructureStart(line string) bool {
+	content := strings.TrimSpace(stripDiffPrefix(strings.TrimLeft(line, " \t")))
+	if content == "{" || content == "[" || content == "}" || content == "]" {
+		return false
+	}
+	return strings.HasSuffix(content, "{") || strings.HasSuffix(content, "[")
+}
+
+func stripDiffPrefix(s string) string {
+	if hasDiffPrefix(s) {
+		return s[2:]
+	}
+	return s
+}
+
+func (m *Model) isFoldCollapsed(block foldBlock) bool {
+	if collapsed, ok := m.foldedBlocks[block.Key]; ok {
+		return collapsed
+	}
+	return block.LineCount >= defaultCollapsedFoldLines
+}
+
+func (m Model) renderFoldHeader(line string, action parser.Action, block foldBlock, collapsed, selected bool, maxWidth int) string {
+	indicator := expandedIndicator
+	if collapsed {
+		indicator = collapsedIndicator
+	}
+
+	rendered := m.wrapAndColorize(line, action, maxWidth)
+	indent := extractIndent(line)
+	content := strings.TrimPrefix(rendered, indent)
+	if block.HeredocPair {
+		content = updateSymbol + " " + mutedColor.Render(fmt.Sprintf("heredoc diff <<-%s", block.HeredocEndMark))
+	}
+	result := indent + indicator + " " + content
+	if block.HeredocPair {
+		result += mutedColor.Render(fmt.Sprintf(" (%d → %d lines)", block.OldLineCount, block.NewLineCount))
+	} else if collapsed {
+		result += mutedColor.Render(fmt.Sprintf(" ... (%d lines)", block.LineCount))
+	}
+	if !selected {
+		return result
+	}
+
+	targetWidth := m.width - 4
+	if targetWidth <= 0 {
+		targetWidth = maxWidth
+	}
+	if targetWidth > 0 && utf8.RuneCountInString(stripANSI(result)) < targetWidth {
+		result += strings.Repeat(" ", targetWidth-utf8.RuneCountInString(stripANSI(result)))
+	}
+	return lipgloss.NewStyle().Background(selectedBg).Foreground(textColor).Render(result)
+}
+
+func renderExpandedHeredocLines(lines []string) string {
+	if len(lines) == 0 {
+		return ""
+	}
+
+	contentLines := lines[:len(lines)-1]
+	baseIndent := heredocContentBaseIndent(contentLines)
+	var b strings.Builder
+	for _, contentLine := range contentLines {
+		b.WriteString(colorizeHeredocContentLine(contentLine, baseIndent))
+		b.WriteString("\n")
+	}
+	b.WriteString(lines[len(lines)-1])
+	b.WriteString("\n")
+	return b.String()
+}
+
+func renderHeredocPairFoldDiff(lines []string, block foldBlock, maxWidth int, contextSize int) string {
+	oldContent := extractHeredocContent(lines[block.Start+1 : block.OldEnd-1])
+	newContent := extractHeredocContent(lines[block.AddStart+1 : block.End-1])
+
+	diff := ComputeDiff(oldContent, newContent)
+	contextDiff := ContextDiff(diff, contextSize)
+	if contextDiff == nil {
+		return ""
+	}
+
+	baseIndent := extractIndent(lines[block.Start])
+	var b strings.Builder
+	b.WriteString(baseIndent)
+	b.WriteString(mutedColor.Render("┄┄┄ heredoc diff ┄┄┄"))
+	b.WriteString("\n")
+	renderDiffLines(&b, contextDiff, baseIndent, maxWidth)
+	b.WriteString(baseIndent)
+	b.WriteString(mutedColor.Render("┄┄┄ end heredoc diff ┄┄┄"))
+	b.WriteString("\n")
+	return b.String()
+}
+
+// renderExpandedContent renders the expanded lines for a resource, applying
+// word wrapping, userdata decoding, YAML/heredoc diff detection, and generic
+// collapsible folds for multiline attributes and nested blocks.
+func (m *Model) renderExpandedContent(b *strings.Builder, r parser.Resource, selected bool, lineCount *int) {
+	maxWidth := m.viewport.Width
+	lines := r.RawLines[1:]
+	folds := findFoldBlocks(r, lines)
+	foldsByStart := make(map[int]foldBlock, len(folds))
+	for _, block := range folds {
+		foldsByStart[block.Start] = block
+	}
+
+	foldIdx := 0
+	for idx := 0; idx < len(lines); idx++ {
+		line := lines[idx]
+
+		if decoded, ok := m.tryRenderUserdata(line, r.Action, maxWidth); ok {
+			b.WriteString(decoded)
+			b.WriteString("\n")
+			*lineCount += strings.Count(decoded, "\n") + 1
+			continue
+		}
+
+		if block, ok := foldsByStart[idx]; ok {
+			blockSelected := selected && foldIdx == m.blockCursor
+			if blockSelected {
+				m.selectedLineStart = *lineCount
+			}
+			collapsed := m.isFoldCollapsed(block)
+			b.WriteString(m.renderFoldHeader(line, r.Action, block, collapsed, blockSelected, maxWidth))
+			b.WriteString("\n")
+			*lineCount++
+			foldIdx++
+
+			if collapsed {
+				idx = block.End - 1
+				continue
+			}
+			if block.HeredocPair {
+				rendered := renderHeredocPairFoldDiff(lines, block, maxWidth, m.diffContextSize())
+				b.WriteString(rendered)
+				*lineCount += strings.Count(rendered, "\n")
+				idx = block.End - 1
+				continue
+			}
+			if block.Heredoc {
+				rendered := renderExpandedHeredocLines(lines[idx+1 : block.End])
+				b.WriteString(rendered)
+				*lineCount += strings.Count(rendered, "\n")
+				idx = block.End - 1
+				continue
+			}
+			continue
+		}
+
+		if consumed, rendered := m.tryRenderHeredocDiff(lines, idx, r.Action, maxWidth); consumed > 0 {
 			b.WriteString(rendered)
+			b.WriteString("\n")
+			*lineCount += strings.Count(rendered, "\n") + 1
 			idx += consumed - 1
 			continue
 		}
 
-		coloredLine := m.wrapAndColorize(line, action, maxWidth)
+		if consumed, rendered := m.tryRenderHeredocBlock(lines, idx, r.Action, maxWidth); consumed > 0 {
+			b.WriteString(rendered)
+			*lineCount += strings.Count(rendered, "\n")
+			idx += consumed - 1
+			continue
+		}
+
+		coloredLine := m.wrapAndColorize(line, r.Action, maxWidth)
 		b.WriteString(coloredLine)
 		b.WriteString("\n")
+		*lineCount++
 	}
+
+}
+
+func findBalancedStructureBlockEnd(lines []string, start int) int {
+	open, close, ok := foldDelimiters(lines[start])
+	if !ok {
+		return -1
+	}
+
+	depth := 0
+	for i := start; i < len(lines); i++ {
+		depth += strings.Count(lines[i], open) - strings.Count(lines[i], close)
+		if i > start && depth <= 0 {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+func foldDelimiters(line string) (open, close string, ok bool) {
+	content := strings.TrimSpace(stripDiffPrefix(strings.TrimLeft(line, " \t")))
+	switch {
+	case strings.HasSuffix(content, "{"):
+		return "{", "}", true
+	case strings.HasSuffix(content, "["):
+		return "[", "]", true
+	default:
+		return "", "", false
+	}
+}
+
+func (m Model) tryRenderHeredocBlock(lines []string, idx int, action parser.Action, maxWidth int) (int, string) {
+	if idx >= len(lines) {
+		return 0, ""
+	}
+
+	endMarker := parseHeredocMarkerFromLine(lines[idx])
+	if endMarker == "" {
+		return 0, ""
+	}
+
+	end := findHeredocBlockEnd(lines, idx+1, endMarker)
+	if end < 0 {
+		return 0, ""
+	}
+
+	contentLines := lines[idx+1 : end-1]
+	baseIndent := heredocContentBaseIndent(contentLines)
+
+	var b strings.Builder
+	b.WriteString(m.wrapAndColorize(lines[idx], action, maxWidth))
+	b.WriteString("\n")
+	for _, contentLine := range contentLines {
+		b.WriteString(colorizeHeredocContentLine(contentLine, baseIndent))
+		b.WriteString("\n")
+	}
+	b.WriteString(lines[end-1])
+	b.WriteString("\n")
+	return end - idx, b.String()
+}
+
+func parseHeredocMarkerFromLine(line string) string {
+	trimmed := strings.TrimLeft(line, " \t")
+	if hasDiffPrefix(trimmed) {
+		trimmed = trimmed[2:]
+	}
+
+	idx := strings.Index(trimmed, "<<")
+	if idx < 0 {
+		return ""
+	}
+
+	marker := strings.TrimSpace(trimmed[idx:])
+	switch {
+	case strings.HasPrefix(marker, "<<-"):
+		marker = strings.TrimSpace(marker[3:])
+	case strings.HasPrefix(marker, "<<"):
+		marker = strings.TrimSpace(marker[2:])
+	default:
+		return ""
+	}
+
+	fields := strings.Fields(marker)
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.TrimSuffix(fields[0], ",")
+}
+
+func hasDiffPrefix(s string) bool {
+	return len(s) >= 2 && s[1] == ' ' && (s[0] == '+' || s[0] == '-' || s[0] == '~')
+}
+
+func heredocContentBaseIndent(lines []string) int {
+	minAll := -1
+	minNonDiffLike := -1
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		trimmed := strings.TrimLeft(line, " \t")
+		indentLen := len(line) - len(trimmed)
+		if minAll < 0 || indentLen < minAll {
+			minAll = indentLen
+		}
+		if !hasDiffPrefix(trimmed) {
+			if minNonDiffLike < 0 || indentLen < minNonDiffLike {
+				minNonDiffLike = indentLen
+			}
+		}
+	}
+
+	if minNonDiffLike >= 0 {
+		return minNonDiffLike
+	}
+	return minAll
+}
+
+func colorizeHeredocContentLine(line string, baseIndent int) string {
+	trimmed := strings.TrimLeft(line, " \t")
+	if !hasDiffPrefix(trimmed) || baseIndent < 2 {
+		return line
+	}
+
+	indent := line[:len(line)-len(trimmed)]
+	if len(indent) != baseIndent-2 {
+		return line
+	}
+
+	prefix := trimmed[:1]
+	content := trimmed[2:]
+	switch prefix {
+	case "+":
+		prefix = lipgloss.NewStyle().Foreground(createColor).Render(prefix)
+	case "-":
+		prefix = lipgloss.NewStyle().Foreground(destroyColor).Render(prefix)
+	case "~":
+		prefix = lipgloss.NewStyle().Foreground(updateColor).Render(prefix)
+	}
+
+	return indent + prefix + " " + content
 }
 
 // wrapAndColorize wraps a raw HCL line to the viewport width and colorizes
@@ -1063,7 +1683,7 @@ func (m Model) renderUserdataDiff(oldB64, newB64, key, decodedIndent string, hea
 		oldLines := strings.Split(oldDecoded, "\n")
 		newLines := strings.Split(newDecoded, "\n")
 		diff := ComputeDiff(oldLines, newLines)
-		contextDiff := ContextDiff(diff, 3)
+		contextDiff := ContextDiff(diff, m.diffContextSize())
 		if contextDiff == nil {
 			b.WriteString(decodedIndent)
 			b.WriteString(mutedColor.Render("  (no changes in decoded content)"))
@@ -1196,11 +1816,22 @@ func parseHeredocEnd(s string) string {
 func findHeredocBlockEnd(lines []string, startIdx int, endMarker string) int {
 	for i := startIdx; i < len(lines); i++ {
 		lt := strings.TrimSpace(lines[i])
-		if lt == endMarker || lt == endMarker+"," {
+		if isHeredocEndLine(lt, endMarker) {
 			return i + 1
 		}
 	}
 	return -1
+}
+
+func isHeredocEndLine(trimmedLine, endMarker string) bool {
+	if trimmedLine == endMarker || trimmedLine == endMarker+"," {
+		return true
+	}
+	rest, ok := strings.CutPrefix(trimmedLine, endMarker)
+	if !ok {
+		return false
+	}
+	return strings.HasPrefix(rest, " -> ") || strings.HasPrefix(rest, ", -> ")
 }
 
 // findAddHeredocStart finds the "+ <<-EOT" line, skipping blank lines. Returns -1 if not found.
@@ -1248,7 +1879,7 @@ func (m Model) renderHeredocPairDiff(lines []string, idx int, maxWidth int) (int
 	}
 
 	diff := ComputeDiff(oldContent, newContent)
-	contextDiff := ContextDiff(diff, 3)
+	contextDiff := ContextDiff(diff, m.diffContextSize())
 	if contextDiff == nil {
 		return 0, ""
 	}
@@ -1306,7 +1937,7 @@ func (m Model) renderPrefixedBlockDiff(lines []string, idx int, action parser.Ac
 	}
 
 	diff := ComputeDiff(oldContent, newContent)
-	contextDiff := ContextDiff(diff, 3)
+	contextDiff := ContextDiff(diff, m.diffContextSize())
 	if contextDiff == nil {
 		return 0, ""
 	}
@@ -1816,18 +2447,42 @@ func (m Model) viewConfirmationPrompt() string {
 
 // viewHelpFooter returns the help footer text.
 func (m Model) viewHelpFooter() string {
+	maxWidth := m.width - 4
+	if maxWidth <= 0 {
+		maxWidth = m.viewport.Width
+	}
+
 	if m.applyMode {
 		if m.confirmApply {
 			return "y: confirm apply • any key: cancel"
 		}
 		applyHint := lipgloss.NewStyle().Foreground(createColor).Bold(true).Render("a: APPLY")
-		return fmt.Sprintf("%s • j/k/↑↓: navigate • e/c: all • /: search • f: filter • s: sort • q: quit", applyHint)
+		full := fmt.Sprintf("%s • j/k/↑↓: navigate • e/c: all • /: search • f: filter • s: sort • q: quit", applyHint)
+		if lipgloss.Width(full) <= maxWidth {
+			return full
+		}
+		return fmt.Sprintf("%s • j/k nav • e/c all • / search • q", applyHint)
 	}
-	help := "j/k/↑↓: navigate • l/→: expand • h/←/⌫: collapse • d/u: scroll • e/c: all • gg/G: top/bottom • /: search • f: filter • s: sort • q: quit"
+
+	helpOptions := []string{
+		"j/k/↑↓: navigate • l/→: expand • h/←/⌫: collapse • e/c: expand/collapse scope • +/-: diff context • Ctrl+E/Y: line scroll • d/u: page scroll • gg/G: top/bottom • /: search • f: filter • s: sort • q: quit",
+		"j/k: nav • l/h: fold • e/c: scope • +/-: diff ctx • Ctrl+E/Y: line • d/u: page • /: search • f/s • q",
+		"j/k nav • l/h fold • e/c scope • +/- diff • Ctrl+E/Y scroll • / search • q",
+		"j/k nav • l/h fold • e/c • q",
+	}
+
 	if len(m.statusFilters) > 0 {
-		help += " • Esc: clear filter"
+		for i, help := range helpOptions {
+			helpOptions[i] = help + " • Esc clears filter"
+		}
 	}
-	return help
+
+	for _, help := range helpOptions {
+		if lipgloss.Width(help) <= maxWidth {
+			return help
+		}
+	}
+	return helpOptions[len(helpOptions)-1]
 }
 
 // viewUpdateNudge renders the update available nudge.

--- a/internal/tui/model_render_test.go
+++ b/internal/tui/model_render_test.go
@@ -417,6 +417,67 @@ func TestSetCurrentScopeFoldsCollapsedSubBlockScope(t *testing.T) {
 	}
 }
 
+func TestExpandAndCollapseEverythingAffectsAllDisplayedResourcesAndFolds(t *testing.T) {
+	resources := []parser.Resource{
+		{
+			Address: "helm_release.chart",
+			Action:  parser.ActionUpdate,
+			RawLines: []string{
+				`  ~ resource "helm_release" "chart" {`,
+				`      ~ metadata = {`,
+				`          ~ values = {`,
+				`              nested = true`,
+				`            }`,
+				`        }`,
+			},
+		},
+		{
+			Address: "kubectl_manifest.vmagent",
+			Action:  parser.ActionUpdate,
+			RawLines: []string{
+				`  ~ resource "kubectl_manifest" "vmagent" {`,
+				`      ~ yaml_body_parsed = <<-EOT`,
+				`            spec:`,
+				`              replicas: 3`,
+				`        EOT`,
+			},
+		},
+	}
+	m := Model{
+		plan:         &parser.Plan{Resources: resources},
+		expanded:     map[int]bool{0: false, 1: false},
+		foldedBlocks: make(map[string]bool),
+		blockCursor:  1,
+	}
+
+	m.expandEverything()
+	for idx := range resources {
+		if !m.expanded[idx] {
+			t.Fatalf("expected resource %d to be expanded", idx)
+		}
+		for _, block := range findFoldBlocks(resources[idx], resources[idx].RawLines[1:]) {
+			if m.foldedBlocks[block.Key] {
+				t.Fatalf("expected fold %q to be expanded", block.Key)
+			}
+		}
+	}
+	if m.blockCursor != -1 {
+		t.Fatalf("expected block cursor to reset after global expand, got %d", m.blockCursor)
+	}
+
+	m.collapseEverything()
+	for idx := range resources {
+		if m.expanded[idx] {
+			t.Fatalf("expected resource %d to be collapsed", idx)
+		}
+		for _, block := range findFoldBlocks(resources[idx], resources[idx].RawLines[1:]) {
+			if !m.foldedBlocks[block.Key] {
+				t.Fatalf("expected fold %q to be collapsed", block.Key)
+			}
+		}
+	}
+}
+
 func TestViewHelpFooterUsesCompactTextForNarrowWidths(t *testing.T) {
 	m := Model{width: 72}
 	got := m.viewHelpFooter()

--- a/internal/tui/model_render_test.go
+++ b/internal/tui/model_render_test.go
@@ -1,0 +1,429 @@
+package tui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/CaptShanks/terraprism/internal/parser"
+)
+
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripRenderANSI(s string) string {
+	return ansiPattern.ReplaceAllString(s, "")
+}
+
+func renderExpandedForTest(r parser.Resource, lines []string) string {
+	return renderExpandedWithDiffContextForTest(r, lines, 0)
+}
+
+func renderExpandedWithDiffContextForTest(r parser.Resource, lines []string, diffContext int) string {
+	r.RawLines = append([]string{`  ~ resource "test" "example" {`}, lines...)
+	m := Model{
+		viewport:     viewport.New(120, 40),
+		foldedBlocks: make(map[string]bool),
+		blockCursor:  -1,
+		diffContext:  diffContext,
+	}
+	var b strings.Builder
+	lineCount := 0
+	m.renderExpandedContent(&b, r, false, &lineCount)
+	return stripRenderANSI(b.String())
+}
+
+func renderedHasLine(rendered, line string) bool {
+	for _, renderedLine := range strings.Split(rendered, "\n") {
+		if renderedLine == line {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRenderHeredocPreservesYAMLListIndentation(t *testing.T) {
+	r := parser.Resource{Type: "kubectl_manifest", Action: parser.ActionUpdate}
+	lines := []string{
+		`      ~ yaml_body_parsed = <<-EOT`,
+		`            spec:`,
+		`              affinity:`,
+		`                nodeAffinity:`,
+		`                  requiredDuringSchedulingIgnoredDuringExecution:`,
+		`                    nodeSelectorTerms:`,
+		`                    - matchExpressions:`,
+		`                      - key: dedicated`,
+		`                        operator: In`,
+		`                        values:`,
+		`                        - utility`,
+		`        EOT`,
+	}
+
+	got := renderExpandedForTest(r, lines)
+
+	for _, want := range []string{
+		`                    - matchExpressions:`,
+		`                      - key: dedicated`,
+		`                        - utility`,
+	} {
+		if !renderedHasLine(got, want) {
+			t.Fatalf("rendered heredoc missing correctly indented line %q:\n%s", want, got)
+		}
+	}
+	if renderedHasLine(got, `                  - matchExpressions:`) {
+		t.Fatalf("rendered heredoc shifted YAML list indentation left:\n%s", got)
+	}
+}
+
+func TestRenderHeredocPreservesTerraformDiffPrefixColumn(t *testing.T) {
+	r := parser.Resource{Type: "kubectl_manifest", Action: parser.ActionUpdate}
+	lines := []string{
+		`      ~ yaml_body_parsed = <<-EOT`,
+		`            spec:`,
+		`              remoteWrite:`,
+		`              - url: http://internal-write-endpoint.example.local/api/v1/write`,
+		`              - url: http://external-write-endpoint.example.com/api/v1/write`,
+		`          +   - url: http://external-write-endpoint.example.com/api/v1/write`,
+		`        EOT`,
+	}
+
+	got := renderExpandedForTest(r, lines)
+	want := `          +   - url: http://external-write-endpoint.example.com/api/v1/write`
+	if !strings.Contains(got, want) {
+		t.Fatalf("rendered heredoc missing Terraform diff-prefixed YAML line %q:\n%s", want, got)
+	}
+}
+
+func TestRenderGenericLargeBlockCollapsesByDefault(t *testing.T) {
+	r := parser.Resource{Type: "helm_release", Address: "helm_release.chart", Action: parser.ActionUpdate}
+	lines := []string{
+		`      ~ metadata                   = {`,
+		`          ~ app_version    = "v1.132.0" -> (known after apply)`,
+		`          ~ chart          = "example-chart" -> (known after apply)`,
+		`          ~ first_deployed = 1770864889 -> (known after apply)`,
+		`          ~ notes          = <<-EOT`,
+		`                1. Get the application URL by running these commands:`,
+		`                  export POD_NAME=$(kubectl get pods --namespace victoria-metrics)`,
+		`            EOT -> (known after apply)`,
+		`          ~ values         = jsonencode(`,
+		`                {`,
+	}
+	for i := 0; i < 35; i++ {
+		lines = append(lines, `                  key = "value"`)
+	}
+	lines = append(lines,
+		`                }`,
+		`            ) -> (known after apply)`,
+		`        }`,
+		`      ~ values = [`,
+		`          - <<-EOT`,
+		`              controller:`,
+		`                replicaCount: 2`,
+		`            EOT,`,
+		`          + <<-EOT`,
+		`              controller:`,
+		`                replicaCount: 3`,
+		`            EOT,`,
+		`        ]`,
+	)
+
+	r.RawLines = append([]string{`  ~ resource "test" "example" {`}, lines...)
+	blocks := findFoldBlocks(r, r.RawLines[1:])
+	foundValuesFold := false
+	for _, block := range blocks {
+		if strings.Contains(r.RawLines[block.Start+1], `values = [`) {
+			foundValuesFold = true
+			break
+		}
+	}
+	if !foundValuesFold {
+		t.Fatalf("expected top-level values list to be foldable, got %#v", blocks)
+	}
+
+	got := renderExpandedForTest(r, lines)
+
+	for _, want := range []string{
+		`      ▶ ~ metadata                   = { ... (47 lines)`,
+		`      ▼ ~ values = [`,
+		`          ▼ ~ heredoc diff <<-EOT (2 → 2 lines)`,
+		`replicaCount: 2`,
+		`replicaCount: 3`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rendered helm release missing %q:\n%s", want, got)
+		}
+	}
+	for _, hidden := range []string{`app_version`, `Get the application URL`, `key = "value"`} {
+		if strings.Contains(got, hidden) {
+			t.Fatalf("rendered plan still contains collapsed block content %q:\n%s", hidden, got)
+		}
+	}
+	for _, separate := range []string{`          ▶ - <<-EOT`, `          ▶ + <<-EOT`, `          ▼ - <<-EOT`, `          ▼ + <<-EOT`} {
+		if strings.Contains(got, separate) {
+			t.Fatalf("rendered plan still contains separate heredoc fold %q:\n%s", separate, got)
+		}
+	}
+}
+
+func TestPairedHeredocsUseSingleDiffFold(t *testing.T) {
+	r := parser.Resource{
+		Address: "helm_release.chart",
+		Action:  parser.ActionUpdate,
+		RawLines: []string{
+			`  ~ resource "helm_release" "chart" {`,
+			`      ~ values = [`,
+			`          - <<-EOT`,
+			`              controller:`,
+			`                replicaCount: 2`,
+			`            EOT,`,
+			`          + <<-EOT`,
+			`              controller:`,
+			`                replicaCount: 3`,
+			`            EOT,`,
+			`        ]`,
+		},
+	}
+
+	blocks := findFoldBlocks(r, r.RawLines[1:])
+	if len(blocks) != 2 {
+		t.Fatalf("expected values fold and heredoc diff fold, got %#v", blocks)
+	}
+	if !blocks[1].HeredocPair {
+		t.Fatalf("expected second fold to be paired heredoc diff, got %#v", blocks[1])
+	}
+
+	got := renderExpandedForTest(r, r.RawLines[1:])
+	if !strings.Contains(got, `▼ ~ heredoc diff <<-EOT (2 → 2 lines)`) {
+		t.Fatalf("rendered plan missing combined heredoc diff fold:\n%s", got)
+	}
+	if strings.Contains(got, `▼ - <<-EOT`) || strings.Contains(got, `▼ + <<-EOT`) {
+		t.Fatalf("rendered plan contains separate heredoc folds:\n%s", got)
+	}
+}
+
+func TestDiffContextControlsHeredocContextLines(t *testing.T) {
+	r := parser.Resource{
+		Address: "helm_release.chart",
+		Action:  parser.ActionUpdate,
+	}
+	lines := []string{
+		`      ~ values = [`,
+		`          - <<-EOT`,
+		`              before-a: true`,
+		`              before-b: true`,
+		`              before-c: true`,
+		`              target: old`,
+		`              after-a: true`,
+		`              after-b: true`,
+		`              after-c: true`,
+		`            EOT,`,
+		`          + <<-EOT`,
+		`              before-a: true`,
+		`              before-b: true`,
+		`              before-c: true`,
+		`              target: new`,
+		`              after-a: true`,
+		`              after-b: true`,
+		`              after-c: true`,
+		`            EOT,`,
+		`        ]`,
+	}
+
+	withoutContext := renderExpandedWithDiffContextForTest(r, lines, 0)
+	if strings.Contains(withoutContext, `before-a: true`) || strings.Contains(withoutContext, `after-c: true`) {
+		t.Fatalf("expected zero diff context to hide far context lines:\n%s", withoutContext)
+	}
+	if !strings.Contains(withoutContext, `target: old`) || !strings.Contains(withoutContext, `target: new`) {
+		t.Fatalf("expected changed lines to remain visible with zero context:\n%s", withoutContext)
+	}
+
+	withContext := renderExpandedWithDiffContextForTest(r, lines, 3)
+	for _, want := range []string{`before-a: true`, `before-b: true`, `before-c: true`, `after-a: true`, `after-b: true`, `after-c: true`} {
+		if !strings.Contains(withContext, want) {
+			t.Fatalf("expected expanded diff context to include %q:\n%s", want, withContext)
+		}
+	}
+}
+
+func TestDiffContextHotkeysClampContext(t *testing.T) {
+	m := Model{
+		plan:        &parser.Plan{},
+		viewport:    viewport.New(80, 20),
+		diffContext: defaultDiffContext,
+	}
+
+	m, _, handled := handleKeyIncreaseDiffContext(m)
+	if !handled {
+		t.Fatal("expected increase diff context key to be handled")
+	}
+	if got, want := m.diffContextSize(), defaultDiffContext+diffContextStep; got != want {
+		t.Fatalf("diff context after increase = %d, want %d", got, want)
+	}
+
+	for i := 0; i < 20; i++ {
+		m, _, _ = handleKeyIncreaseDiffContext(m)
+	}
+	if got := m.diffContextSize(); got != maxDiffContext {
+		t.Fatalf("diff context should clamp to max %d, got %d", maxDiffContext, got)
+	}
+
+	for i := 0; i < 20; i++ {
+		m, _, _ = handleKeyDecreaseDiffContext(m)
+	}
+	if got := m.diffContextSize(); got != 0 {
+		t.Fatalf("diff context should clamp to 0, got %d", got)
+	}
+}
+
+func TestVisibleFoldBlocksExcludesChildrenOfCollapsedParent(t *testing.T) {
+	r := parser.Resource{
+		Address: "helm_release.chart",
+		Action:  parser.ActionUpdate,
+		RawLines: []string{
+			`  ~ resource "helm_release" "chart" {`,
+			`      ~ metadata = {`,
+			`          ~ values = {`,
+			`              nested = true`,
+			`            }`,
+			`        }`,
+		},
+	}
+	m := Model{
+		plan:         &parser.Plan{Resources: []parser.Resource{r}},
+		expanded:     map[int]bool{0: true},
+		foldedBlocks: make(map[string]bool),
+		blockCursor:  -1,
+	}
+	blocks := findFoldBlocks(r, r.RawLines[1:])
+	if len(blocks) != 2 {
+		t.Fatalf("expected parent and child folds, got %d", len(blocks))
+	}
+
+	m.foldedBlocks[blocks[0].Key] = true
+	visible := m.currentFoldBlocks()
+	if len(visible) != 1 {
+		t.Fatalf("expected only collapsed parent to be visible, got %d", len(visible))
+	}
+	if visible[0].Key != blocks[0].Key {
+		t.Fatalf("expected visible fold to be parent, got %q", visible[0].Key)
+	}
+}
+
+func TestVisibleFoldBlocksIncludesChildrenOfExpandedParent(t *testing.T) {
+	r := parser.Resource{
+		Address: "helm_release.chart",
+		Action:  parser.ActionUpdate,
+		RawLines: []string{
+			`  ~ resource "helm_release" "chart" {`,
+			`      ~ metadata = {`,
+			`          ~ values = {`,
+			`              nested = true`,
+			`            }`,
+			`        }`,
+		},
+	}
+	m := Model{
+		plan:         &parser.Plan{Resources: []parser.Resource{r}},
+		expanded:     map[int]bool{0: true},
+		foldedBlocks: make(map[string]bool),
+		blockCursor:  -1,
+	}
+
+	visible := m.currentFoldBlocks()
+	if len(visible) != 2 {
+		t.Fatalf("expected parent and child folds to be visible, got %d", len(visible))
+	}
+	if visible[0].Start != 0 || visible[1].Start != 1 {
+		t.Fatalf("unexpected visible fold order: %#v", visible)
+	}
+}
+
+func TestSetCurrentScopeFoldsCollapsedResourceScope(t *testing.T) {
+	r := parser.Resource{
+		Address: "helm_release.chart",
+		Action:  parser.ActionUpdate,
+		RawLines: []string{
+			`  ~ resource "helm_release" "chart" {`,
+			`      ~ metadata = {`,
+			`          ~ values = {`,
+			`              nested = true`,
+			`            }`,
+			`        }`,
+		},
+	}
+	m := Model{
+		plan:         &parser.Plan{Resources: []parser.Resource{r}},
+		expanded:     map[int]bool{0: true},
+		foldedBlocks: make(map[string]bool),
+		blockCursor:  -1,
+	}
+
+	if !m.setCurrentScopeFoldsCollapsed(true) {
+		t.Fatal("expected resource-scope collapse to apply")
+	}
+	for _, block := range findFoldBlocks(r, r.RawLines[1:]) {
+		if !m.foldedBlocks[block.Key] {
+			t.Fatalf("expected fold %q to be collapsed", block.Key)
+		}
+	}
+
+	if !m.setCurrentScopeFoldsCollapsed(false) {
+		t.Fatal("expected resource-scope expand to apply")
+	}
+	for _, block := range findFoldBlocks(r, r.RawLines[1:]) {
+		if m.foldedBlocks[block.Key] {
+			t.Fatalf("expected fold %q to be expanded", block.Key)
+		}
+	}
+}
+
+func TestSetCurrentScopeFoldsCollapsedSubBlockScope(t *testing.T) {
+	r := parser.Resource{
+		Address: "helm_release.chart",
+		Action:  parser.ActionUpdate,
+		RawLines: []string{
+			`  ~ resource "helm_release" "chart" {`,
+			`      ~ metadata = {`,
+			`          ~ values = {`,
+			`              nested = true`,
+			`            }`,
+			`        }`,
+			`      ~ set = {`,
+			`          value = true`,
+			`        }`,
+		},
+	}
+	m := Model{
+		plan:         &parser.Plan{Resources: []parser.Resource{r}},
+		expanded:     map[int]bool{0: true},
+		foldedBlocks: make(map[string]bool),
+		blockCursor:  0,
+	}
+	blocks := findFoldBlocks(r, r.RawLines[1:])
+	if len(blocks) != 3 {
+		t.Fatalf("expected metadata, values, and set folds, got %#v", blocks)
+	}
+
+	if !m.setCurrentScopeFoldsCollapsed(true) {
+		t.Fatal("expected sub-block-scope collapse to apply")
+	}
+	if !m.foldedBlocks[blocks[0].Key] || !m.foldedBlocks[blocks[1].Key] {
+		t.Fatalf("expected selected fold and descendant to collapse: %#v", m.foldedBlocks)
+	}
+	if m.foldedBlocks[blocks[2].Key] {
+		t.Fatalf("did not expect sibling fold to collapse: %#v", m.foldedBlocks)
+	}
+}
+
+func TestViewHelpFooterUsesCompactTextForNarrowWidths(t *testing.T) {
+	m := Model{width: 72}
+	got := m.viewHelpFooter()
+	if lipgloss.Width(got) > 68 {
+		t.Fatalf("help footer width = %d, want <= 68: %q", lipgloss.Width(got), got)
+	}
+	if strings.Contains(got, "expand/collapse scope") {
+		t.Fatalf("expected compact help footer, got %q", got)
+	}
+}

--- a/release-notes/v0.12.0.md
+++ b/release-notes/v0.12.0.md
@@ -3,6 +3,7 @@
 - **Generic collapsible sub-blocks** — expanded plan resources now fold large maps, lists, and heredocs without provider-specific rules.
 - **Sub-object navigation** — when a resource is expanded, `j`/`k` can move into foldable child blocks and `Enter`/`Space`, `h`, and `l` toggle the selected block.
 - **Scoped recursive fold controls** — `e` and `c` expand or collapse all foldable content under the selected resource or sub-block.
+- **Global fold controls** — use `E` and `C` to expand or collapse all visible resources and nested foldable blocks.
 - **Combined heredoc diffs** — paired remove/add heredocs render as one foldable diff section instead of separate old/new blocks.
 - **Adjustable diff context** — use `+`/`=` to show more unchanged lines around diff hunks, or `-` to tighten the view.
 - **One-line viewport scrolling** — use `Ctrl+E` and `Ctrl+Y` to scroll through large expanded blocks without moving the selected resource or fold.
@@ -19,6 +20,7 @@
 # - Expand a resource with Enter/Space
 # - Use j/k to move into foldable sub-blocks
 # - Use h/l or Enter/Space to collapse/expand a selected sub-block
+# - Use E/C to expand/collapse everything visible
 # - Use +/- to change diff context around changed lines
 # - Use Ctrl+E/Ctrl+Y to scroll one line inside large expanded content
 terraprism plan

--- a/release-notes/v0.12.0.md
+++ b/release-notes/v0.12.0.md
@@ -1,0 +1,25 @@
+### Added
+
+- **Generic collapsible sub-blocks** — expanded plan resources now fold large maps, lists, and heredocs without provider-specific rules.
+- **Sub-object navigation** — when a resource is expanded, `j`/`k` can move into foldable child blocks and `Enter`/`Space`, `h`, and `l` toggle the selected block.
+- **Scoped recursive fold controls** — `e` and `c` expand or collapse all foldable content under the selected resource or sub-block.
+- **Combined heredoc diffs** — paired remove/add heredocs render as one foldable diff section instead of separate old/new blocks.
+- **Adjustable diff context** — use `+`/`=` to show more unchanged lines around diff hunks, or `-` to tighten the view.
+- **One-line viewport scrolling** — use `Ctrl+E` and `Ctrl+Y` to scroll through large expanded blocks without moving the selected resource or fold.
+
+### Fixed
+
+- Preserve YAML indentation inside heredoc attributes such as `kubectl_manifest.yaml_body_parsed`, including nested Kubernetes lists.
+- Reduce noisy `helm_release.metadata` output through generic folding instead of hardcoded provider-specific hiding.
+
+### Usage
+
+```bash
+# In the TUI:
+# - Expand a resource with Enter/Space
+# - Use j/k to move into foldable sub-blocks
+# - Use h/l or Enter/Space to collapse/expand a selected sub-block
+# - Use +/- to change diff context around changed lines
+# - Use Ctrl+E/Ctrl+Y to scroll one line inside large expanded content
+terraprism plan
+```


### PR DESCRIPTION
## Summary

This PR fixes issue #16 by improving how large Terraform plan objects are rendered and navigated in the TUI.

The main change is structural: expanded resources are no longer treated as one flat text block. The renderer now identifies nested object-like sections inside a resource, such as maps, lists, and heredocs, and turns them into foldable sub-objects. This makes large provider output, especially `helm_release` values and metadata, reviewable without hardcoding provider-specific hiding rules.

## Go Structure Changes

- Extends the TUI `Model` with fold/navigation state for expanded resource internals:
  - tracks the selected foldable sub-object separately from the selected resource
  - tracks collapsed state per fold key
  - tracks adjustable diff context for rendered diff hunks

- Adds a new internal `foldBlock` representation for structural sections inside a resource:
  - records start/end line ranges
  - tracks whether the block is a heredoc, a paired heredoc diff, or a normal map/list block
  - stores line counts and heredoc metadata for compact fold headers

- Splits rendering into smaller structural helpers:
  - fold discovery for maps, lists, and heredocs
  - visible fold filtering when parent blocks are collapsed
  - fold header rendering
  - heredoc-aware content rendering
  - paired heredoc diff rendering
  - diff context rendering for heredocs, prefixed blocks, and decoded user-data

- Keeps parser objects unchanged:
  - no changes to `parser.Resource`
  - no changes to parsed `RawLines`
  - no CLI flags or exported API changes

## Object Structure Changes

- Adds generic foldable sub-objects inside expanded resources:
  - maps like `metadata = { ... }`
  - lists like `values = [ ... ]`
  - heredocs like `yaml_body_parsed = <<-EOT`

- Adds sub-object navigation:
  - `j` / `k` can move between resources and foldable sub-objects
  - `Enter` / `Space`, `h`, and `l` toggle the selected resource or sub-object
  - `e` / `c` recursively expand or collapse all foldable content under the selected resource or sub-object

- Combines paired heredoc diffs into one structural diff section:
  - old/new heredocs are rendered as a single foldable `heredoc diff`
  - `+` / `=` and `-` adjust unchanged context around diff hunks
  - heredoc indentation is preserved, including nested YAML lists

## Why

Large Terraform plan sections, especially Helm values and Kubernetes YAML bodies, were difficult to review because they rendered as huge flat blocks. YAML list indentation could also be shifted incorrectly, making the rendered output misleading.

This keeps the fix display-only and generic. Instead of adding provider-specific suppression for `helm_release.metadata`, the TUI now gives users structural folding controls that work across resource types.

## Validation

- `PATH=/opt/homebrew/bin:$PATH go test ./...`
- `PATH=/opt/homebrew/bin:$PATH make build`
- `git diff --check`

Coverage improved from 9.1% to 21.5% overall, mostly from new TUI rendering tests.
