### PR TITLE
fix: bind TUI colors to shell theme and scope e/c hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ terraform plan -no-color | terraprism -p
 | `Enter` / `Space` | Toggle current resource or foldable sub-block |
 | `l` / `→` | Expand current resource or foldable sub-block |
 | `h` / `←` / `⌫` | Collapse current resource or foldable sub-block |
-| `e` | Expand all resources, or all foldable sub-blocks in the current scope |
-| `c` | Collapse all resources, or all foldable sub-blocks in the current scope |
-| `E` | Expand all visible resources and all nested foldable sub-blocks |
-| `C` | Collapse all visible resources and all nested foldable sub-blocks |
+| `e` | Expand the highlighted item and its foldable sub-blocks (scope) |
+| `c` | Collapse the highlighted item and its foldable sub-blocks (scope) |
+| `Shift+E` | Expand all visible resources and all nested foldable sub-blocks |
+| `Shift+C` | Collapse all visible resources and all nested foldable sub-blocks |
 
 Large maps, lists, and heredocs inside expanded resources become foldable sub-blocks. Large sub-blocks collapse by default; use `l`/`→` or `Enter`/`Space` to expand them, then `Ctrl+E`/`Ctrl+Y` to scroll through the expanded content without moving the selection. When a resource or sub-block is selected, `e` and `c` recursively expand or collapse the foldable content underneath that selection.
 

--- a/internal/tui/expand_bug_test.go
+++ b/internal/tui/expand_bug_test.go
@@ -1,0 +1,136 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/viewport"
+
+	"github.com/CaptShanks/terraprism/internal/parser"
+)
+
+func threeResourcesWithFolds() []parser.Resource {
+	return []parser.Resource{
+		{Address: "a.one", Action: parser.ActionUpdate, RawLines: []string{
+			`  ~ resource "a" "one" {`, `      x = 1`, `    }`,
+		}},
+		{Address: "b.two", Action: parser.ActionUpdate, RawLines: []string{
+			`  ~ resource "b" "two" {`,
+			`      ~ metadata = {`, `          ~ values = {`, `              nested = true`, `            }`, `        }`,
+			`    }`,
+		}},
+		{Address: "c.three", Action: parser.ActionUpdate, RawLines: []string{
+			`  ~ resource "c" "three" {`, `      x = 3`, `    }`,
+		}},
+	}
+}
+
+// `e` at root scopes to the highlighted item: expand cursor's resource and its
+// sub-folds, but leave siblings untouched.
+func TestExpandAllScopesToHighlightedItem(t *testing.T) {
+	resources := threeResourcesWithFolds()
+	m := Model{
+		plan:         &parser.Plan{Resources: resources},
+		expanded:     map[int]bool{},
+		foldedBlocks: make(map[string]bool),
+		blockCursor:  -1,
+		viewport:     viewport.New(120, 40),
+		cursor:       1, // b.two
+	}
+
+	updated, _, _ := handleKeyExpandAll(m)
+
+	if !updated.expanded[1] {
+		t.Fatalf("cursor's resource (b.two) should be expanded; expanded=%v", updated.expanded)
+	}
+	if updated.expanded[0] || updated.expanded[2] {
+		t.Fatalf("siblings should NOT have been expanded by scoped `e`; expanded=%v", updated.expanded)
+	}
+	for _, block := range findFoldBlocks(resources[1], resources[1].RawLines[1:]) {
+		if updated.foldedBlocks[block.Key] {
+			t.Fatalf("sub-fold %q of cursor's resource should be expanded after `e`", block.Key)
+		}
+	}
+}
+
+// `c` at root collapses just the cursor's item and its sub-folds.
+func TestCollapseAllScopesToHighlightedItem(t *testing.T) {
+	resources := threeResourcesWithFolds()
+	m := Model{
+		plan:         &parser.Plan{Resources: resources},
+		expanded:     map[int]bool{0: true, 1: true, 2: true},
+		foldedBlocks: make(map[string]bool),
+		blockCursor:  -1,
+		viewport:     viewport.New(120, 40),
+		cursor:       1,
+	}
+
+	updated, _, _ := handleKeyCollapseAll(m)
+
+	if updated.expanded[1] {
+		t.Fatalf("cursor's resource should be collapsed; expanded=%v", updated.expanded)
+	}
+	if !updated.expanded[0] || !updated.expanded[2] {
+		t.Fatalf("siblings should remain expanded; expanded=%v", updated.expanded)
+	}
+}
+
+// Shift+E (handleKeyExpandEverything) is the global expand-all.
+func TestExpandEverythingIsGlobal(t *testing.T) {
+	resources := threeResourcesWithFolds()
+	m := Model{
+		plan:         &parser.Plan{Resources: resources},
+		expanded:     map[int]bool{},
+		foldedBlocks: make(map[string]bool),
+		blockCursor:  -1,
+		viewport:     viewport.New(120, 40),
+		cursor:       1,
+	}
+
+	updated, _, _ := handleKeyExpandEverything(m)
+
+	for idx := range resources {
+		if !updated.expanded[idx] {
+			t.Fatalf("resource %d should be expanded by `E`; expanded=%v", idx, updated.expanded)
+		}
+	}
+}
+
+// Shift+C is the global collapse-all.
+func TestCollapseEverythingIsGlobal(t *testing.T) {
+	resources := threeResourcesWithFolds()
+	m := Model{
+		plan:         &parser.Plan{Resources: resources},
+		expanded:     map[int]bool{0: true, 1: true, 2: true},
+		foldedBlocks: make(map[string]bool),
+		blockCursor:  -1,
+		viewport:     viewport.New(120, 40),
+		cursor:       1,
+	}
+
+	updated, _, _ := handleKeyCollapseEverything(m)
+
+	for idx := range resources {
+		if updated.expanded[idx] {
+			t.Fatalf("resource %d should be collapsed by `C`; expanded=%v", idx, updated.expanded)
+		}
+	}
+}
+
+// Inside a sub-fold, `e` still scopes to that fold.
+func TestExpandAllInsideSubBlockKeepsScope(t *testing.T) {
+	resources := threeResourcesWithFolds()
+	m := Model{
+		plan:         &parser.Plan{Resources: resources},
+		expanded:     map[int]bool{1: true},
+		foldedBlocks: make(map[string]bool),
+		blockCursor:  0,
+		viewport:     viewport.New(120, 40),
+		cursor:       1,
+	}
+
+	updated, _, _ := handleKeyExpandAll(m)
+
+	if updated.expanded[0] {
+		t.Fatalf("sibling 0 should NOT expand from sub-block-scoped `e`; expanded=%v", updated.expanded)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -910,25 +910,6 @@ func (m *Model) setDisplayedFoldsCollapsed(collapsed bool) {
 	}
 }
 
-// expandAll expands all visible (filtered/sorted) resources
-func (m *Model) expandAll() {
-	for _, idx := range m.displayedResourceIndices() {
-		m.expanded[idx] = true
-	}
-	m.updateViewportContent()
-	m.ensureCursorVisible()
-}
-
-// collapseAll collapses all visible (filtered/sorted) resources
-func (m *Model) collapseAll() {
-	for _, idx := range m.displayedResourceIndices() {
-		m.expanded[idx] = false
-	}
-	m.blockCursor = -1
-	m.updateViewportContent()
-	m.ensureCursorVisible()
-}
-
 // expandEverything expands all visible resources and their nested fold blocks.
 func (m *Model) expandEverything() {
 	for _, idx := range m.displayedResourceIndices() {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -481,25 +481,46 @@ func handleKeyEnter(m Model) (Model, tea.Cmd, bool) {
 	return m, nil, true
 }
 
+// handleKeyExpandAll expands the cursor's current scope recursively:
+//   - inside a sub-fold: that fold and its descendants
+//   - at root: the cursor's resource and all its sub-folds
+//
+// Use Shift+E (handleKeyExpandEverything) for a global expand across all resources.
 func handleKeyExpandAll(m Model) (Model, tea.Cmd, bool) {
-	if m.setCurrentScopeFoldsCollapsed(false) {
+	if m.blockCursor >= 0 && m.setCurrentScopeFoldsCollapsed(false) {
 		m.updateViewportContent()
 		m.ensureCursorVisible()
 		return m, nil, true
 	}
 
-	m.expandAll()
+	filtered := m.displayedResourceIndices()
+	if len(filtered) > 0 && m.cursor >= 0 && m.cursor < len(filtered) {
+		m.expanded[filtered[m.cursor]] = true
+		m.setCurrentScopeFoldsCollapsed(false)
+	}
+	m.updateViewportContent()
+	m.ensureCursorVisible()
 	return m, nil, true
 }
 
+// handleKeyCollapseAll collapses the cursor's current scope recursively.
+// Use Shift+C (handleKeyCollapseEverything) for a global collapse.
 func handleKeyCollapseAll(m Model) (Model, tea.Cmd, bool) {
-	if m.setCurrentScopeFoldsCollapsed(true) {
+	if m.blockCursor >= 0 && m.setCurrentScopeFoldsCollapsed(true) {
 		m.updateViewportContent()
 		m.ensureCursorVisible()
 		return m, nil, true
 	}
 
-	m.collapseAll()
+	filtered := m.displayedResourceIndices()
+	if len(filtered) > 0 && m.cursor >= 0 && m.cursor < len(filtered) {
+		idx := filtered[m.cursor]
+		m.setCurrentScopeFoldsCollapsed(true)
+		m.expanded[idx] = false
+		m.blockCursor = -1
+	}
+	m.updateViewportContent()
+	m.ensureCursorVisible()
 	return m, nil, true
 }
 
@@ -1179,7 +1200,7 @@ func (m *Model) renderResources() string {
 	m.contentLineCount = lineCount
 
 	b.WriteString("\n")
-	eolStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#6c7086"))
+	eolStyle := lipgloss.NewStyle().Foreground(mutedColorVal)
 	b.WriteString(eolStyle.Render("── End of Plan ──"))
 	b.WriteString("\n")
 
@@ -2487,8 +2508,8 @@ func (m Model) viewConfirmationPrompt() string {
 		return ""
 	}
 	confirmStyle := lipgloss.NewStyle().
-		Background(lipgloss.Color("#f38ba8")).
-		Foreground(lipgloss.Color("#1e1e2e")).
+		Background(destroyColor).
+		Foreground(textColor).
 		Bold(true).
 		Padding(0, 2)
 	return "\n" + confirmStyle.Render("⚠️  Apply this plan? Press 'y' to confirm, any other key to cancel") + "\n\n"
@@ -2506,11 +2527,15 @@ func (m Model) viewHelpFooter() string {
 			return "y: confirm apply • any key: cancel"
 		}
 		applyHint := lipgloss.NewStyle().Foreground(createColor).Bold(true).Render("a: APPLY")
-		full := fmt.Sprintf("%s • j/k/↑↓: navigate • e/c: all • /: search • f: filter • s: sort • q: quit", applyHint)
+		full := fmt.Sprintf("%s • j/k/↑↓: navigate • e/c: scope • E/C: all • /: search • f: filter • s: sort • q: quit", applyHint)
 		if lipgloss.Width(full) <= maxWidth {
 			return full
 		}
-		return fmt.Sprintf("%s • j/k nav • e/c all • / search • q", applyHint)
+		medium := fmt.Sprintf("%s • j/k nav • e/c scope • E/C all • / search • q", applyHint)
+		if lipgloss.Width(medium) <= maxWidth {
+			return medium
+		}
+		return fmt.Sprintf("%s • j/k nav • e/c • / search • q", applyHint)
 	}
 
 	helpOptions := []string{
@@ -2539,7 +2564,7 @@ func (m Model) viewUpdateNudge() string {
 	if m.updateAvailable == "" {
 		return ""
 	}
-	nudgeStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("86")).Italic(true)
+	nudgeStyle := lipgloss.NewStyle().Foreground(computedColor).Italic(true)
 	return "\n" + nudgeStyle.Render(fmt.Sprintf("Update available: v%s. Run 'terraprism upgrade' to update.", m.updateAvailable))
 }
 

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -231,11 +231,11 @@ func pickerEntryStatus(status string) (label string, style lipgloss.Style) {
 	s := lipgloss.NewStyle()
 	switch status {
 	case "success":
-		return "[SUCCESS]", s.Foreground(lipgloss.Color("#a6e3a1"))
+		return "[SUCCESS]", s.Foreground(createColor)
 	case "failed":
-		return "[FAILED]", s.Foreground(lipgloss.Color("#f38ba8"))
+		return "[FAILED]", s.Foreground(destroyColor)
 	case "cancelled":
-		return "[CANCELLED]", s.Foreground(lipgloss.Color("#fab387"))
+		return "[CANCELLED]", s.Foreground(updateColor)
 	default:
 		return "", s
 	}
@@ -253,7 +253,7 @@ func pickerTruncatePath(path string, maxLen int) string {
 
 func (m PickerModel) pickerViewEntries(b *strings.Builder) {
 	if len(m.filtered) == 0 {
-		noResultStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#6c7086")).Italic(true)
+		noResultStyle := lipgloss.NewStyle().Foreground(mutedColorVal).Italic(true)
 		if m.searchQuery != "" {
 			b.WriteString(noResultStyle.Render(fmt.Sprintf("  No results for '%s'", m.searchQuery)))
 		} else {
@@ -279,14 +279,14 @@ func (m PickerModel) pickerViewEntries(b *strings.Builder) {
 		}
 	}
 	if startIdx > 0 {
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#6c7086")).Render(fmt.Sprintf("  ↑ %d more entries above", startIdx)))
+		b.WriteString(lipgloss.NewStyle().Foreground(mutedColorVal).Render(fmt.Sprintf("  ↑ %d more entries above", startIdx)))
 		b.WriteString("\n")
 	}
 	for i := startIdx; i < endIdx; i++ {
 		m.pickerWriteEntryLine(b, i)
 	}
 	if endIdx < len(m.filtered) {
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#6c7086")).Render(fmt.Sprintf("  ↓ %d more entries below", len(m.filtered)-endIdx)))
+		b.WriteString(lipgloss.NewStyle().Foreground(mutedColorVal).Render(fmt.Sprintf("  ↓ %d more entries below", len(m.filtered)-endIdx)))
 		b.WriteString("\n")
 	}
 }
@@ -296,7 +296,7 @@ func (m PickerModel) pickerWriteEntryLine(b *strings.Builder, i int) {
 	cursor, style := "  ", lipgloss.NewStyle()
 	if i == m.cursor {
 		cursor = "> "
-		style = lipgloss.NewStyle().Background(lipgloss.Color("#313244")).Foreground(lipgloss.Color("#cdd6f4")).Bold(true)
+		style = lipgloss.NewStyle().Background(selectedBg).Foreground(textColor).Bold(true)
 	}
 	statusLabel, statusStyle := pickerEntryStatus(entry.Status)
 	path := pickerTruncatePath(entry.WorkingDir, 40)
@@ -317,19 +317,19 @@ func (m PickerModel) pickerWriteEntryLine(b *strings.Builder, i int) {
 
 func (m PickerModel) pickerViewFooter(b *strings.Builder) {
 	if m.searching {
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#f9e2af")).Bold(true).Render("/ "))
+		b.WriteString(lipgloss.NewStyle().Foreground(updateColor).Bold(true).Render("/ "))
 		b.WriteString(m.searchQuery)
 		b.WriteString("█")
 		return
 	}
 	if m.searchQuery != "" {
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#f9e2af")).Render(fmt.Sprintf("Filter: %s", m.searchQuery)))
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#6c7086")).Render(fmt.Sprintf("  (%d/%d)", len(m.filtered), len(m.allEntries))))
+		b.WriteString(lipgloss.NewStyle().Foreground(updateColor).Render(fmt.Sprintf("Filter: %s", m.searchQuery)))
+		b.WriteString(lipgloss.NewStyle().Foreground(mutedColorVal).Render(fmt.Sprintf("  (%d/%d)", len(m.filtered), len(m.allEntries))))
 		b.WriteString("\n")
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#6c7086")).Render("j/k/↑↓: navigate  d/u: scroll  enter: select  esc: clear filter  q: cancel"))
+		b.WriteString(lipgloss.NewStyle().Foreground(mutedColorVal).Render("j/k/↑↓: navigate  d/u: scroll  enter: select  esc: clear filter  q: cancel"))
 		return
 	}
-	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#6c7086")).Render("j/k/↑↓: navigate  d/u: scroll  /: search  enter: select  q: cancel"))
+	b.WriteString(lipgloss.NewStyle().Foreground(mutedColorVal).Render("j/k/↑↓: navigate  d/u: scroll  /: search  enter: select  q: cancel"))
 }
 
 func (m PickerModel) View() string {
@@ -337,9 +337,9 @@ func (m PickerModel) View() string {
 		return ""
 	}
 	var b strings.Builder
-	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#89b4fa")).MarginBottom(1).Render("Select a history entry to view"))
+	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(headerColor).MarginBottom(1).Render("Select a history entry to view"))
 	b.WriteString("\n\n")
-	headerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#6c7086")).Bold(true)
+	headerStyle := lipgloss.NewStyle().Foreground(mutedColorVal).Bold(true)
 	b.WriteString(headerStyle.Render("     TIMESTAMP        COMMAND  STATUS        PATH"))
 	b.WriteString("\n")
 	b.WriteString(headerStyle.Render(strings.Repeat("─", 95)))

--- a/internal/tui/state_model.go
+++ b/internal/tui/state_model.go
@@ -942,7 +942,7 @@ func (m *StateModel) renderDetailContent() string {
 		}
 		taintedBadge := ""
 		if strings.Contains(block, "(tainted)") {
-			taintedBadge = lipgloss.NewStyle().Foreground(lipgloss.Color("#f9e2af")).Bold(true).Render("⊗ ") 
+			taintedBadge = lipgloss.NewStyle().Foreground(updateColor).Bold(true).Render("⊗ ")
 		}
 		headerStyle := lipgloss.NewStyle().Foreground(headerColor).Bold(true)
 		b.WriteString(mutedColor.Render(symbol))
@@ -1010,7 +1010,7 @@ func (m *StateModel) renderList() string {
 		}
 		taintBadge := ""
 		if m.tainted[addr] {
-			taintBadge = lipgloss.NewStyle().Foreground(lipgloss.Color("#f9e2af")).Bold(true).Render(" ⊗")
+			taintBadge = lipgloss.NewStyle().Foreground(updateColor).Bold(true).Render(" ⊗")
 		}
 		addrStyle := stateAddressStyle(addr)
 		line := marker + addr + taintBadge
@@ -1061,7 +1061,7 @@ func (m StateModel) View() string {
 	b.WriteString("\n")
 	help := "j/k: navigate • g/G: first/last • pgup/pgdn: page • Space: select • Ctrl+Space: range • Enter: show • t: taint • u: untaint • d/x: rm • /: search • f: sort • Esc: clear • q: quit"
 	if m.flashMsg != "" {
-		flashStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#a6e3a1")).Bold(true)
+		flashStyle := lipgloss.NewStyle().Foreground(createColor).Bold(true)
 		help = flashStyle.Render("✓ "+m.flashMsg) + "  " + helpStyle.Render(help)
 	} else {
 		help = helpStyle.Render(help)
@@ -1094,7 +1094,7 @@ func (m StateModel) viewDetail() string {
 		help = m.detailCopyFeedback + " • " + help
 	}
 	if m.flashMsg != "" {
-		flashStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#a6e3a1")).Bold(true)
+		flashStyle := lipgloss.NewStyle().Foreground(createColor).Bold(true)
 		help = flashStyle.Render("✓ "+m.flashMsg) + "  " + help
 	}
 	b.WriteString(helpStyle.Render(help))
@@ -1114,10 +1114,10 @@ func (m StateModel) viewWithConfirmation() string {
 		msg = "Confirm? (y/N)"
 	}
 	confirmStyle := lipgloss.NewStyle().
-		Background(lipgloss.Color("#45475a")).
-		Foreground(lipgloss.Color("#cdd6f4")).
+		Background(selectedBg).
+		Foreground(textColor).
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("#f38ba8")).
+		BorderForeground(destroyColor).
 		Padding(0, 2)
 	var b strings.Builder
 	b.WriteString(headerStyle.Render("🔺 Terra-Prism - State Viewer"))

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/termenv"
 )
 
-// Color palette variables - will be set based on background detection
+// Color palette - bound to terminal ANSI slots so the app follows the user's shell theme.
 var (
 	createColor   lipgloss.Color
 	destroyColor  lipgloss.Color
@@ -21,91 +20,50 @@ var (
 	computedColor lipgloss.Color
 )
 
-// Catppuccin Mocha (Dark) palette
-var darkPalette = map[string]string{
-	"green":    "#a6e3a1",
-	"red":      "#f38ba8",
-	"yellow":   "#f9e2af",
-	"mauve":    "#cba6f7",
-	"sapphire": "#74c7ec",
-	"blue":     "#89b4fa",
-	"teal":     "#94e2d5",
-	"text":     "#cdd6f4",
-	"subtext":  "#a6adc8",
-	"overlay":  "#7f849c",
-	"surface1": "#45475a",
-	"surface0": "#313244",
-	"mantle":   "#181825",
-	"base":     "#1e1e2e",
+// ANSI 16-color slot assignments. Terminals remap these per theme, so the app
+// inherits whatever palette the user has set in their shell.
+var ansiPalette = map[string]string{
+	"green":   "2",  // create
+	"red":     "1",  // destroy
+	"yellow":  "3",  // update
+	"magenta": "5",  // replace
+	"cyan":    "6",  // read / computed
+	"blue":    "4",  // header / info
+	"gray":    "8",  // muted / selection bg (bright black)
+	"text":    "",   // inherit terminal default foreground
 }
 
-// Catppuccin Latte (Light) palette
-var lightPalette = map[string]string{
-	"green":    "#40a02b",
-	"red":      "#d20f39",
-	"yellow":   "#df8e1d",
-	"mauve":    "#8839ef",
-	"sapphire": "#209fb5",
-	"blue":     "#1e66f5",
-	"teal":     "#179299",
-	"text":     "#4c4f69",
-	"subtext":  "#6c6f85",
-	"overlay":  "#8c8fa1",
-	"surface1": "#bcc0cc",
-	"surface0": "#ccd0da",
-	"mantle":   "#e6e9ef",
-	"base":     "#eff1f5",
-}
-
-// IsLightBackground returns true if terminal has a light background
+// IsLightBackground is retained for backward compatibility. With ANSI-bound
+// colors the terminal owns the palette, so this no longer drives styling.
 func IsLightBackground() bool {
-	return !termenv.HasDarkBackground()
+	return false
 }
 
 func init() {
-	// Initialize colors based on detected background
 	InitColors()
 }
 
-// InitColors sets the color palette based on terminal background
+// InitColors assigns the ANSI palette and (re)builds the lipgloss styles.
 func InitColors() {
-	if IsLightBackground() {
-		SetLightPalette()
-	} else {
-		SetDarkPalette()
-	}
+	createColor = lipgloss.Color(ansiPalette["green"])
+	destroyColor = lipgloss.Color(ansiPalette["red"])
+	updateColor = lipgloss.Color(ansiPalette["yellow"])
+	replaceColor = lipgloss.Color(ansiPalette["magenta"])
+	readColor = lipgloss.Color(ansiPalette["cyan"])
+	headerColor = lipgloss.Color(ansiPalette["blue"])
+	mutedColorVal = lipgloss.Color(ansiPalette["gray"])
+	selectedBg = lipgloss.Color(ansiPalette["gray"])
+	textColor = lipgloss.Color(ansiPalette["text"])
+	computedColor = lipgloss.Color(ansiPalette["cyan"])
 	initStyles()
 }
 
-// SetDarkPalette sets colors for dark backgrounds (Catppuccin Mocha)
-func SetDarkPalette() {
-	createColor = lipgloss.Color(darkPalette["green"])
-	destroyColor = lipgloss.Color(darkPalette["red"])
-	updateColor = lipgloss.Color(darkPalette["yellow"])
-	replaceColor = lipgloss.Color(darkPalette["mauve"])
-	readColor = lipgloss.Color(darkPalette["sapphire"])
-	selectedBg = lipgloss.Color(darkPalette["surface1"])
-	headerColor = lipgloss.Color(darkPalette["blue"])
-	mutedColorVal = lipgloss.Color(darkPalette["overlay"])
-	textColor = lipgloss.Color(darkPalette["text"])
-	computedColor = lipgloss.Color(darkPalette["teal"])
-	initStyles() // Reinitialize styles with new colors
-}
+// SetDarkPalette is kept for backward compatibility. Colors now follow the
+// terminal's ANSI palette, so explicit dark/light selection is unnecessary.
+func SetDarkPalette() { InitColors() }
 
-// SetLightPalette sets colors for light backgrounds (Catppuccin Latte)
-func SetLightPalette() {
-	createColor = lipgloss.Color(lightPalette["green"])
-	destroyColor = lipgloss.Color(lightPalette["red"])
-	updateColor = lipgloss.Color(lightPalette["yellow"])
-	replaceColor = lipgloss.Color(lightPalette["mauve"])
-	readColor = lipgloss.Color(lightPalette["sapphire"])
-	selectedBg = lipgloss.Color(lightPalette["surface1"])
-	headerColor = lipgloss.Color(lightPalette["blue"])
-	mutedColorVal = lipgloss.Color(lightPalette["overlay"])
-	textColor = lipgloss.Color(lightPalette["text"])
-	computedColor = lipgloss.Color(lightPalette["teal"])
-	initStyles() // Reinitialize styles with new colors
-}
+// SetLightPalette is kept for backward compatibility. See SetDarkPalette.
+func SetLightPalette() { InitColors() }
 
 // Styles - initialized after colors are set
 var (
@@ -294,16 +252,16 @@ func FormatStatusColored(status string) string {
 	switch status {
 	case "success":
 		label = "[SUCCESS]"
-		style = lipgloss.NewStyle().Foreground(createColor) // green
+		style = lipgloss.NewStyle().Foreground(createColor)
 	case "failed":
 		label = "[FAILED]"
-		style = lipgloss.NewStyle().Foreground(destroyColor) // red
+		style = lipgloss.NewStyle().Foreground(destroyColor)
 	case "cancelled":
 		label = "[CANCELLED]"
-		style = lipgloss.NewStyle().Foreground(updateColor) // yellow/orange
+		style = lipgloss.NewStyle().Foreground(updateColor)
 	case "pending":
 		label = "[PENDING]"
-		style = lipgloss.NewStyle().Foreground(lipgloss.Color("#fab387")) // orange
+		style = lipgloss.NewStyle().Foreground(updateColor)
 	case "nochanges":
 		return ""
 	default:
@@ -324,7 +282,7 @@ func FormatHistoryEntryColored(timestamp, command, status, path string) string {
 	case "destroy":
 		cmdStyle = cmdStyle.Foreground(destroyColor)
 	case "plan":
-		cmdStyle = cmdStyle.Foreground(lipgloss.Color("#89b4fa")) // blue
+		cmdStyle = cmdStyle.Foreground(headerColor)
 	}
 	cmdColored := cmdStyle.Render(cmdPadded)
 
@@ -343,7 +301,7 @@ func FormatHistoryEntryColored(timestamp, command, status, path string) string {
 		statusColored = lipgloss.NewStyle().Foreground(updateColor).Render(statusPadded)
 	case "pending":
 		statusPadded = fmt.Sprintf("%-12s", "[PENDING]")
-		statusColored = lipgloss.NewStyle().Foreground(lipgloss.Color("#fab387")).Render(statusPadded)
+		statusColored = lipgloss.NewStyle().Foreground(updateColor).Render(statusPadded)
 	default:
 		statusColored = statusPadded // no color, just spaces
 	}


### PR DESCRIPTION
- Replace hardcoded Catppuccin hex palettes with ANSI 16-color slots so the UI follows whatever palette the terminal theme defines. Backward compat: SetLightPalette/SetDarkPalette become no-ops; TERRAPRISM_THEME still parses without error.
- e/c now scope to the highlighted item (cursor's resource + its sub-folds, or the current sub-fold when blockCursor >= 0). Shift+E/C remain global. Fixes regression where pressing e on an already-expanded item only opened its sub-folds while siblings stayed collapsed.
- Apply-mode help footer now reads "e/c: scope • E/C: all", matching the rest of the UI.